### PR TITLE
Update perfview-diagnostic-information.md

### DIFF
--- a/support/dotnet/framework/perfview-diagnostic-information.md
+++ b/support/dotnet/framework/perfview-diagnostic-information.md
@@ -4,7 +4,7 @@ description: List information that's collected by the PerfView diagnostic tool.
 ms.date: 05/08/2020
 ms.prod-support-area-path:
 ---
-# [SDP 3] [f0fc366d-d20d-4606-a0e9-1d8787336906] PerfView diagnostic
+# Information collected by PerfView
 
 This article describes the information that may be collected from a machine when running the PerfView diagnostic tool.
 


### PR DESCRIPTION
The title of this page should be the as written title in the markdown metadata and in the left side TOC, instead of unknown/strange `[SDP] [f0fc366d-d20d-4606-a0e9-1d8787336906] PerfView diagnostic`.

![image](https://user-images.githubusercontent.com/8773147/109125848-2463bc00-777f-11eb-8755-447a5b9245f4.png)
