### PR TITLE
Updated Section 2. Check which TLS is enabled

### DIFF
--- a/support/azure/virtual-machines/troubleshoot-rdp-internal-error.md
+++ b/support/azure/virtual-machines/troubleshoot-rdp-internal-error.md
@@ -260,7 +260,7 @@ To enable dump log and Serial Console, run the following script.
 
     REG ADD "HKLM\BROKENSYSTEM\ControlSet002\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server" /v Enabled /t REG_DWORD /d 1 /f
 
-    REG ADD "HKLM\BROKENSYSTEM\ControlSet002\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" /v Enabled /t REG_DWO
+    REG ADD "HKLM\BROKENSYSTEM\ControlSet002\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" /v Enabled /t REG_DWORD /d 1 /f
     ```
 
 3. If the key doesn't exist, or its value is **0**, enable the protocol by running the following scripts:


### PR DESCRIPTION
the last line on Section 2 : Check which TLS is enabled. The command seems to be cut off half way and getting syntax error.
```REG ADD "HKLM\BROKENSYSTEM\ControlSet002\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" /v Enabled /t REG_DWO```

Proposed change to for the command to run properly.
```REG ADD "HKLM\BROKENSYSTEM\ControlSet002\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server" /v Enabled /t REG_DWORD /d 1 /f```