### PR TITLE
Remove the use of SET ROWCOUNT and GOTO in incremental delete example

### DIFF
--- a/support/sql/performance/resolve-blocking-problems-caused-lock-escalation.md
+++ b/support/sql/performance/resolve-blocking-problems-caused-lock-escalation.md
@@ -40,10 +40,10 @@ The simplest and safest way to prevent lock escalation is to keep transactions s
 
     ```sql
     DECLARE @done bit = 0;
-WHILE (@done = 0)
+    WHILE (@done = 0)
     BEGIN
         DELETE TOP(1000) FROM LogMessages WHERE LogDate < '20020102';
-                IF @@rowcount < 1000 SET @done = 1;
+        IF @@rowcount < 1000 SET @done = 1;
     END;
     ```
 

--- a/support/sql/performance/resolve-blocking-problems-caused-lock-escalation.md
+++ b/support/sql/performance/resolve-blocking-problems-caused-lock-escalation.md
@@ -39,11 +39,11 @@ The simplest and safest way to prevent lock escalation is to keep transactions s
   By removing these records a few hundred at a time, you can dramatically reduce the number of locks that accumulate per transaction and prevent lock escalation. For example:
 
     ```sql
-    DECLARE @rows int = 500;
-    WHILE (@rows > = 500)
+    DECLARE @done bit = 0;
+WHILE (@done = 0)
     BEGIN
-        DELETE TOP(500) FROM LogMessages WHERE LogDate < '20020102';
-        SET @rows = @@ROWCOUNT;
+        DELETE TOP(1000) FROM LogMessages WHERE LogDate < '20020102';
+                IF @@rowcount < 1000 SET @done = 1;
     END;
     ```
 

--- a/support/sql/performance/resolve-blocking-problems-caused-lock-escalation.md
+++ b/support/sql/performance/resolve-blocking-problems-caused-lock-escalation.md
@@ -39,10 +39,11 @@ The simplest and safest way to prevent lock escalation is to keep transactions s
   By removing these records a few hundred at a time, you can dramatically reduce the number of locks that accumulate per transaction and prevent lock escalation. For example:
 
     ```sql
-    WHILE (1 = 1)
+    DECLARE @rows int = 500;
+    WHILE (@rows > = 500)
     BEGIN
         DELETE TOP(500) FROM LogMessages WHERE LogDate < '20020102';
-        IF @@ROWCOUNT < 500 BREAK;
+        SET @rows = @@ROWCOUNT;
     END;
     ```
 


### PR DESCRIPTION
We aren't supposed to use SET ROWCOUNT in relation to DELETE statements any more (according to T-SQL documentation), and GOTO and labels are always a poor idea. It's much easier (and better practice) to just use TOP() with the DELETE to achieve the same outcome. So I've updated the example to do so. I also added statement terminators in the examples, and removed the use of regional-specific date formats that would only work in the USA. (Change to a date format that's not affected by region or language settings)