### PR TITLE
Inconsistent registry locations

### DIFF
--- a/support/windows-server/identity/configure-authoritative-time-server.md
+++ b/support/windows-server/identity/configure-authoritative-time-server.md
@@ -28,14 +28,14 @@ To configure the PDC in the root of an Active Directory forest to synchronize wi
 1. Change the server type to NTP. To do this, follow these steps:
    1. Select **Start** > **Run**, type *regedit*, and then select **OK**.
    2. Locate and then select the following registry subkey:  
-      `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Parameters\Type`
+      `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Parameters`
 
    3. In the pane on the right, right-click **Type**, and then select **Modify**.
    4. In **Edit Value**, type *NTP* in the **Value data** box, and then select **OK**.
 
 2. Set `AnnounceFlags` to 5. To do this, follow these steps:
    1. Locate and then select the following registry subkey:
-      `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config\AnnounceFlags`
+      `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config`
 
    2. In the pane on the right, right-click **AnnounceFlags**, and then select **Modify**.
    3. In **Edit DWORD Value**, type *5* in the **Value data** box, and then select **OK**.
@@ -64,7 +64,7 @@ To configure the PDC in the root of an Active Directory forest to synchronize wi
 
 4. Configure the time correction settings. To do this, follow these steps:
    1. Locate and then click the following registry subkey:
-  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config\MaxPosPhaseCorrection`
+  `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config`
 
    2. In the pane on the right, right-click **MaxPosPhaseCorrection**, and then select **Modify**.
    3. In **Edit DWORD Value**, click to select **Decimal** in the **Base** box.
@@ -75,7 +75,7 @@ To configure the PDC in the root of an Active Directory forest to synchronize wi
       > The default value of **MaxPosPhaseCorrection** is 48 hours in Windows Server 2008 R2 or later.
 
    5. Locate and then click the following registry subkey:  
-      `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config\MaxNegPhaseCorrection`
+      `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config`
 
    6. In the pane on the right, right-click **MaxNegPhaseCorrection**, and then select **Modify**.
    7. In **Edit DWORD Value**, click to select **Decimal** in the **Base** box.


### PR DESCRIPTION
The document `configure-authoritative-time-server.md` has five registry locations listed in it but they are inconsistent:
- four registry locations include the registry value name in them.
- fifth registry location does not include the registry value name and only lists keys.

This could be fixed to be consistent either by adding the registry value name to the fifth registry location or by taking out the registry value name from the four registry locations.
I opted for the latter approach since the registry locations are listed as "the following registry subkey" and the registry value name is listed separately.