### PR TITLE
Fix issue with SDDL format

### DIFF
--- a/support/windows-server/shell-experience/access-denied-runas-command-run-as-administrator.md
+++ b/support/windows-server/shell-experience/access-denied-runas-command-run-as-administrator.md
@@ -63,7 +63,7 @@ To do this, follow these steps:
 3. At the command prompt, type the following command, and then press ENTER:
 
     ```console
-    sc sdset seclogon d:(a;;cclcswrpwpdtlocrrc;;;sy)(a;;ccdclcswrpwpdtlocrsdrcwdwo;;;ba)(a;;cclcswrpdtlocrrc;;;iu)(a;;cclcswdtlocrrc;;;su)(a;;cclcswrpdtlocrrc;;;au)s:(au;fa;ccdclcswrpwpdtlocrsdrcwdwo;;;wd)  
+    sc sdset seclogon D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWRPDTLOCRRC;;;IU)(A;;CCLCSWDTLOCRRC;;;SU)(A;;CCLCSWRPDTLOCRRC;;;AU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)
     ```
 
     > [!NOTE]


### PR DESCRIPTION
Running the command as provided yields a failure message. 
The SDDL format needs to be in CAPITAL letters, not lowercase. 
Updated the command to be in CAPITAL letters.