### PR TITLE
Adding ToU as another cause for issue with multi-app kiosk profiles

### DIFF
--- a/support/mem/intune/users-cannot-logon-windows-multi-app-kiosk.md
+++ b/support/mem/intune/users-cannot-logon-windows-multi-app-kiosk.md
@@ -16,6 +16,9 @@ _Original KB number:_ &nbsp; 4493932
 
 When a user tries to log on to an Azure AD joined Windows 10 computer that has a multi-app kiosk profile assigned, the attempt fails immediately before the user profile is loaded.
 
+![image](https://user-images.githubusercontent.com/67381934/115788050-19996200-a391-11eb-9c89-e51d59702411.png)
+![image](https://user-images.githubusercontent.com/67381934/115788056-1c945280-a391-11eb-8712-7ae59f9eb257.png)
+
 In this situation, the kiosk profile logon type is **AAD User** or **Group**. Additionally, the Windows 10 computer uses a local account, and you notice the following error messages in the Event Viewer logs:
 
 - AAD - Operational logs (Sample 1 - MFA required):
@@ -27,7 +30,7 @@ In this situation, the kiosk profile logon type is **AAD User** or **Group**. Ad
     > Level:         Error  
     > Keywords:      Error,Error    
     > User:          *[User SID]*          
-	> Computer:      *[Computer Name]*       
+    > Computer:      *[Computer Name]*       
     > Description:                       
     > **Error: 0xCAA2000C The request requires user interaction.**	    
     > **Code: interaction_required**	    
@@ -38,27 +41,27 @@ In this situation, the kiosk profile logon type is **AAD User** or **Group**. Ad
     > Source:        Microsoft-Windows-AAD    
     > Date:          *[Timestamp]*      
     > Event ID:      1098   
-	> Task Category: AadTokenBrokerPlugin Operation     
-	> Level:         Error      
-	> Keywords:      Error,Error        
+    > Task Category: AadTokenBrokerPlugin Operation     
+    > Level:         Error      
+    > Keywords:      Error,Error        
     > User:          *[User SID]*          
-	> Computer:      *[Computer Name]*      
-	> Description:      
+    > Computer:      *[Computer Name]*      
+    > Description:      
     > **Error: 0xCAA2000C The request requires user interaction.**      
     > **Code: interaction_required**        
-	> Description: AADSTS50158: External security challenge not satisfied. User will be redirected to another page or authentication provider to satisfy additional authentication challenges.      
+    > Description: AADSTS50158: External security challenge not satisfied. User will be redirected to another page or authentication provider to satisfy additional authentication challenges.      
 
 - Assigned Access - Admin logs:
-	> Log Name:      Microsoft-Windows-AssignedAccess/Admin     
-	> Source:        Microsoft-Windows-AssignedAccess       
+    > Log Name:      Microsoft-Windows-AssignedAccess/Admin     
+    > Source:        Microsoft-Windows-AssignedAccess       
     > Date:          *[Timestamp]*            
     > Event ID:      31000      
-	> Task Category: Applying Assigned Access for current user.     
-	> Level:         Error      
+    > Task Category: Applying Assigned Access for current user.     
+    > Level:         Error      
     > User:          *[User SID]*          
-	> Computer:      *[Computer Name]*     
-	> Description:      
-	> Error Unspecified error applying assigned access for current user, signing out...     
+    > Computer:      *[Computer Name]*     
+    > Description:      
+    > Error Unspecified error applying assigned access for current user, signing out...     
 
 
 ## Cause

--- a/support/mem/intune/users-cannot-logon-windows-multi-app-kiosk.md
+++ b/support/mem/intune/users-cannot-logon-windows-multi-app-kiosk.md
@@ -1,59 +1,74 @@
 ---
 title: Users can't log on to Windows 10 computers with multi-app kiosk profile assigned
-description: Fixes an issue in which a user cannot log on to an Azure AD-joined Windows 10 computer if a multi-app kiosk profile is assigned.
+description: Fixes an issue in which a user cannot log on to an Azure AD joined Windows 10 computer if a multi-app kiosk profile is assigned.
 ms.date: 09/11/2020
 ms.prod-support-area-path: Configure device restrictions
 ms.reviewer: joelste, intunecic, mobazzar
 ---
 # Users can't log on to Windows if a multi-app kiosk profile is assigned
 
-This article helps you fix an issue in which a user can't log on to an Azure Active Directory (Azure AD)-joined Windows 10 computer if a multi-app kiosk profile is assigned.
+This article helps you fix an issue in which a user can't log on to an Azure AD joined Windows 10 computer if a multi-app kiosk profile is assigned.
 
 _Original product version:_ &nbsp; Microsoft Intune  
 _Original KB number:_ &nbsp; 4493932
 
 ## Symptoms
 
-When a user tries to log on to an Azure AD-joined Windows 10 computer that has a multi-app kiosk profile assigned, the attempt fails immediately before the user profile is loaded.
+When a user tries to log on to an Azure AD joined Windows 10 computer that has a multi-app kiosk profile assigned, the attempt fails immediately before the user profile is loaded.
 
 In this situation, the kiosk profile logon type is **AAD User** or **Group**. Additionally, the Windows 10 computer uses a local account, and you notice the following error messages in the Event Viewer logs:
 
-- Assigned Access logs:
+- AAD - Operational logs (Sample 1 - MFA required):
+    > Log Name:      Microsoft-Windows-AAD/Operational  
+    > Source:        Microsoft-Windows-AAD  
+    > Date:          *[Timestamp]*    
+    > Event ID:      1098   
+    > Task Category: AadTokenBrokerPlugin Operation 
+    > Level:         Error  
+    > Keywords:      Error,Error    
+    > User:          *[User SID]*          
+	> Computer:      *[Computer Name]*       
+    > Description:                       
+    > **Error: 0xCAA2000C The request requires user interaction.**	    
+    > **Code: interaction_required**	    
+    > Description: AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access '00000003-0000-0000-c000-000000000000'.	    
 
-    > Log Name: &nbsp;Microsoft-Windows-AssignedAccess/Admin  
-    > Source: &nbsp; &nbsp; &nbsp; &nbsp;Microsoft-Windows-AssignedAccess  
-    > Date: &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;*DateTime*  
-    > Event ID: &nbsp; &nbsp; &nbsp;31000  
-    > Task Category: Applying Assigned Access for current user.  
-    > Level: &nbsp; &nbsp; &nbsp; &nbsp; Error  
-    > Keywords:  
-    > User: &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;*UserSID*  
-    > Computer: &nbsp; &nbsp; *ComputerName*  
-    > Description:  
-    > Error Unspecified error applying assigned access for current user, signing out...
+- AAD - Operational logs (Sample 2 - ToU required):
+    > Log Name:      Microsoft-Windows-AAD/Operational    
+    > Source:        Microsoft-Windows-AAD    
+    > Date:          *[Timestamp]*      
+    > Event ID:      1098   
+	> Task Category: AadTokenBrokerPlugin Operation     
+	> Level:         Error      
+	> Keywords:      Error,Error        
+    > User:          *[User SID]*          
+	> Computer:      *[Computer Name]*      
+	> Description:      
+    > **Error: 0xCAA2000C The request requires user interaction.**      
+    > **Code: interaction_required**        
+	> Description: AADSTS50158: External security challenge not satisfied. User will be redirected to another page or authentication provider to satisfy additional authentication challenges.      
 
-- AAD logs:
+- Assigned Access - Admin logs:
+	> Log Name:      Microsoft-Windows-AssignedAccess/Admin     
+	> Source:        Microsoft-Windows-AssignedAccess       
+    > Date:          *[Timestamp]*            
+    > Event ID:      31000      
+	> Task Category: Applying Assigned Access for current user.     
+	> Level:         Error      
+    > User:          *[User SID]*          
+	> Computer:      *[Computer Name]*     
+	> Description:      
+	> Error Unspecified error applying assigned access for current user, signing out...     
 
-    > Log Name: &nbsp; Microsoft-Windows-AAD/Operational  
-    > Source: &nbsp; &nbsp; &nbsp; &nbsp;Microsoft-Windows-AAD  
-    > Date: &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;*DateTime*  
-    > Event ID: &nbsp; &nbsp; &nbsp;1098  
-    > Task Category: AadTokenBrokerPlugin Operation  
-    > Level: &nbsp; &nbsp; &nbsp; &nbsp; Error  
-    > Keywords: &nbsp; &nbsp; &nbsp;Error,Error  
-    > User: &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;*UserSID*  
-    > Computer: &nbsp; &nbsp; *ComputerName*  
-    > Description:  
-    > Error: 0xCAA2000C The request requires user interaction.  
-    > Code: interaction_required  
-    > Description: AADSTS50079: Due to a configuration change made by your administrator, or because you moved to a new location, you must enroll in multi-factor authentication to access '00000003-0000-0000-c000-000000000000'.
 
 ## Cause
 
 This behavior is by design.
 
-This issue occurs because the users are targeted by conditional access policies that require multi-factor authentication (MFA). Multi-app kiosk currently doesn't support MFA.
+This issue occurs because the users are targeted by conditional access policies that require user interaction, such as multi-factor authentication (MFA) or Terms of Use (ToU).
 
 ## Resolution
 
-To fix this issue, turn off MFA for the kiosk users.
+To fix this issue, exclude kiosk users from any conditional access policies that require user interaction, such as MFA or ToU.    
+
+If the kiosk user is enabled for MFA, please disable it as MFA is currently not supported in multi-app kiosk mode scenarios.


### PR DESCRIPTION
Issue is not only affected by MFA conditional access policies. Any conditional access policy that requires user interaction will also cause the same behavior. 
Updating explanation for the issue and including screenshots.
Also, the previous resolution as MFA could be disabled for the end users, and the issue would still be present. The correct resolution is for the users to be excluded from CA policy that requires MFA.