### PR TITLE
Update microsoft-store-not-open-domain-joine-computer-vpn.md

### DIFF
--- a/support/windows-client/shell-experience/microsoft-store-not-open-domain-joine-computer-vpn.md
+++ b/support/windows-client/shell-experience/microsoft-store-not-open-domain-joine-computer-vpn.md
@@ -40,7 +40,7 @@ When the Windows Firewall profile isn't **Public**, there's a default block rule
 
 To fix this issue, follow these steps to create a Group Policy object (GPO):
 
-1. Open the Group Policy Management snap-in (gpmc.msc), and open the **Default Domain Policy**  for editing.
+1. Open the Group Policy Management snap-in (gpmc.msc), and create, or open an existing **Group Policy** for editing.
 2. From the Group Policy Management Editor, expand **Computer Configuration** > **Policies** > **Administrative Templates** > **Network**, and then select **Network Isolation**.
 3. In the right pane, double-click **Private network ranges for apps**.
 4. In the **Private network ranges for apps** dialog box, select **Enabled**.

--- a/support/windows-client/shell-experience/microsoft-store-not-open-domain-joine-computer-vpn.md
+++ b/support/windows-client/shell-experience/microsoft-store-not-open-domain-joine-computer-vpn.md
@@ -40,7 +40,7 @@ When the Windows Firewall profile isn't **Public**, there's a default block rule
 
 To fix this issue, follow these steps to create a Group Policy object (GPO):
 
-1. Open the Group Policy Management snap-in (gpmc.msc), and create, or open an existing **Group Policy** for editing.
+1. Open the Group Policy Management snap-in (gpmc.msc), and create, or open a Group Policy for editing.
 2. From the Group Policy Management Editor, expand **Computer Configuration** > **Policies** > **Administrative Templates** > **Network**, and then select **Network Isolation**.
 3. In the right pane, double-click **Private network ranges for apps**.
 4. In the **Private network ranges for apps** dialog box, select **Enabled**.


### PR DESCRIPTION
Documentation shouldn't make use of "Default Domain Policy" as an example in my opinion, as it's generally considered a good practice to not set anything in default domain policies but relevant account related settings: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpod/566e983e-3b72-4b2d-9063-a00ebc9514fd