### PR TITLE
Clarify FAT32 being introduced in Windows 95 OSR2

### DIFF
--- a/support/windows-client/backup-and-storage/fat-hpfs-and-ntfs-file-systems.md
+++ b/support/windows-client/backup-and-storage/fat-hpfs-and-ntfs-file-systems.md
@@ -21,7 +21,7 @@ _Original product version:_ &nbsp; Windows 10 - all editions, Windows Server 201
 _Original KB number:_ &nbsp; 100108
 
 > [!NOTE]
-> HPFS is only supported under Windows NT versions 3.1, 3.5, and 3.51. Windows NT 4.0 does not support and cannot access HPFS partitions. Also, support for the FAT32 file system became available in Windows 98/95(OSR2) and Windows 2000.
+> HPFS is only supported under Windows NT versions 3.1, 3.5, and 3.51. Windows NT 4.0 does not support and cannot access HPFS partitions. Also, support for the FAT32 file system became available in Windows 98/Windows 95 OSR2 and Windows 2000.
 
 ## FAT overview
 

--- a/support/windows-client/backup-and-storage/fat-hpfs-and-ntfs-file-systems.md
+++ b/support/windows-client/backup-and-storage/fat-hpfs-and-ntfs-file-systems.md
@@ -21,7 +21,7 @@ _Original product version:_ &nbsp; Windows 10 - all editions, Windows Server 201
 _Original KB number:_ &nbsp; 100108
 
 > [!NOTE]
-> HPFS is only supported under Windows NT versions 3.1, 3.5, and 3.51. Windows NT 4.0 does not support and cannot access HPFS partitions. Also, the FAT32 file system is only supported in the Windows 98/95 and Windows 2000.
+> HPFS is only supported under Windows NT versions 3.1, 3.5, and 3.51. Windows NT 4.0 does not support and cannot access HPFS partitions. Also, support for the FAT32 file system became available in Windows 98/95(OSR2) and Windows 2000.
 
 ## FAT overview
 


### PR DESCRIPTION
FAT32 filesystem support wasn't available in the original / consumer release of Windows 95.  It was first made available, only with the purchase of a new computer, through Windows 95 OEM Service Release 2 (OSR2).  The first available "upgrade" for Windows 95 was via Windows 98 and, of course, its introduction into the Windows NT line was via Windows 2000 (aka. Windows NT 5).