### PR TITLE
Fix typo in registry paths

### DIFF
--- a/support/aspnet/asp-com-objects-fail-to-print.md
+++ b/support/aspnet/asp-com-objects-fail-to-print.md
@@ -30,19 +30,19 @@ You can set up printers for the SYSTEM account to resolve this problem. To set u
 2. Launch the **Registry Editor** (Regedit.exe).
 3. Select the following key:
 
-    `HKEY_CURRENT_USER\Software\Microsoft\Windows NT\Current Version\Devices`
+    `HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Devices`
 
 4. From the **Registry** menu, select **Export Registry File**.
 5. In the **File Name** text box, type **c:\Devices.reg**.
 6. Select the following key:
 
-    `HKEY_CURRENT_USER\Software\Microsoft\Windows NT\Current Version\PrinterPorts`
+    `HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\PrinterPorts`
 
 7. From the **Registry** menu, select **Export Registry File**.
 8. In the **File Name** text box, type **c:\PrinterPorts.reg**.
 9. Select the following key:
 
-    `HKEY_CURRENT_USER\Software\Microsoft\Windows NT\Current Version\Windows`
+    `HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Windows`
 
 10. From the **Registry** menu, select **Export Registry File**.
 11. In the **File Name** text box, type **c:\Windows.reg**.

--- a/support/windows-client/application-management/add-remove-programs-displays-programs-incorrectly.md
+++ b/support/windows-client/application-management/add-remove-programs-displays-programs-incorrectly.md
@@ -193,7 +193,7 @@ The following list includes all the registry keys that are used by Add/Remove Pr
 
     "{352EC2B7-8B9A-11D1-B8AE-006008059382}"="Shell Application Manager"
 
-- [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Current Version\App Management\Publishers\Darwin App Publisher]
+- [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Management\Publishers\Darwin App Publisher]
 @="{CFCCC7A0-A282-11D1-9082-006008059382}"
 - [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
 "{CFCCC7A0-A282-11D1-9082-006008059382}"="Darwin App Publisher"

--- a/support/windows-client/system-management-components/0x80041323-running-scheduled-tasks.md
+++ b/support/windows-client/system-management-components/0x80041323-running-scheduled-tasks.md
@@ -83,7 +83,7 @@ To resolve this particular issue, increase the value for the quota keys to maxim
 
 1. Click **Start**, type *regedit*, and then press ENTER.
 2. Locate and then click the following registry key:
-   `HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Schedule\Configuration`
+   `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Schedule\Configuration`
 3. Right-click **TasksInMemoryQueue**, click **Edit**, and then click **Modify**.
 4. In the **Value data** box, type *1000* \(Decimal\).
 5. Right-click **TasksPerHighestPrivEngine**, click **Edit**, and then click **Modify**.
@@ -96,7 +96,7 @@ To resolve this particular issue, increase the value for the quota keys to maxim
 
 The Job queue quota is controlled through 'TasksInMemoryQueue' value while the Engine quota is controlled through "TasksPerHighestPrivEngine" and "TasksPerLeastPrivEngine" registry values located under following registry key:  
 
-`HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Schedule\Configuration`
+`HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Schedule\Configuration`
 
 - TasksInMemoryQueue [Default = 75, Max = 1000]
   - Determines the maximum tasks allowed to be queued in the session manager. Once this limit is exceeded, any new task instance scheduled to be executed will be discarded and you'll get the Event ID 131.

--- a/support/windows-client/system-management-components/task-scheduler-task-only-runs-in-background.md
+++ b/support/windows-client/system-management-components/task-scheduler-task-only-runs-in-background.md
@@ -33,7 +33,7 @@ This behavior occurs only if you used SYSPREP to create the master image, and is
 ## Cause
 
 After running sysprep on the machine, the following registry entry will contain the path to Explorer.exe and a comma at the end of the value: "C:\Winnt\Explorer.exe,"
-`HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon\ Shell:REG_SZ:C:\Winnt\Explorer.exe,`  
+`HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ Shell:REG_SZ:C:\Winnt\Explorer.exe,`  
 
 The full path to Explorer.exe, including the command, results in this behavior.
 
@@ -41,7 +41,7 @@ The full path to Explorer.exe, including the command, results in this behavior.
 
 The options to resolve this problem are:
 
-Modify the following registry value removing the path to explorer and the trailing comma at the end of explorer as described in the Cause section above. The value should read exactly as shown here: `HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon\ Shell:REG_SZ:Explorer.exe`  
+Modify the following registry value removing the path to explorer and the trailing comma at the end of explorer as described in the Cause section above. The value should read exactly as shown here: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ Shell:REG_SZ:Explorer.exe`  
 
 -or-
 

--- a/support/windows-server/deployment/change-volume-licensing-product-key.md
+++ b/support/windows-server/deployment/change-volume-licensing-product-key.md
@@ -58,7 +58,7 @@ If you only have a few volume licensing product keys to change, you can use the 
 
 1. Click **Start**, and then click **Run**.
 2. In the **Open** box, type regedit, and then click **OK**.
-3. In the navigation pane, locate and then click the following registry key: `HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\Current Version\WPAEvents` 
+3. In the navigation pane, locate and then click the following registry key: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\WPAEvents` 
 
 4. In the topic pane, right-click **OOBETimer**, and then click **Modify**.
 5. Change at least one digit of this value to deactivate Windows.

--- a/support/windows-server/networking/forwarders-resolution-timeouts.md
+++ b/support/windows-server/networking/forwarders-resolution-timeouts.md
@@ -123,7 +123,7 @@ Similar to forwarders, there are two key variables for Conditional Forwarders. W
 
     Since Conditional Forwarders are configured for specific zones, the **ForwarderTimeout** is zone-dependent as well.
 
-    It's saved in the registry under `HKLM\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\DNS Server\Zones\ <zone_name>\ForwarderTimeout`.
+    It's saved in the registry under `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\DNS Server\Zones\ <zone_name>\ForwarderTimeout`.
 
     The default value is 5 seconds on Windows Server 2003, 2008, 2008R2 and 2012.
 

--- a/support/windows-server/performance/rebuild-performance-counter-library-values.md
+++ b/support/windows-server/performance/rebuild-performance-counter-library-values.md
@@ -34,7 +34,7 @@ This behavior may occur in the following situations:
 
 Extensible counter information is stored in both of the following locations:
 
-- The registry subkey: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\Current Version\Perflib\009`.
+- The registry subkey: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Perflib\009`.
 
 - The `%Systemroot%\System32\Perfc009.dat` file and the `%Systemroot%\System32\Perfh009.dat` file.
 

--- a/support/windows-server/remote/set-up-logon-script-terminal-server-users.md
+++ b/support/windows-server/remote/set-up-logon-script-terminal-server-users.md
@@ -36,7 +36,7 @@ For information about how to edit the registry, view the "Changing Keys And Valu
 
 1. Run Regedt32.exe and go to the following value:
 
-    `HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsNT\CurrentVersion
+    `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion
     \Winlogon\Appsetup`
 
 2. After the last entry in the Appsetup value, place a comma and a space and then enter the name and extension of the logon script you placed in the %SystemRoot%\System32 folder. For example, if the value of Appsetup is:  

--- a/support/windows-server/user-profiles-and-logon/cached-domain-logon-information.md
+++ b/support/windows-server/user-profiles-and-logon/cached-domain-logon-information.md
@@ -45,7 +45,7 @@ For information about how to edit the registry, view the **Changing Keys And Val
 
 Cached logon information is controlled by the following key:
 
-- Location: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\Current Version\Winlogon\`
+- Location: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\`
 - Value name: CachedLogonsCount
 - Data type: REG_SZ
 - Values: 0 - 50

--- a/support/windows-server/virtualization/feature-performance-optimization-hyper-v-replica.md
+++ b/support/windows-server/virtualization/feature-performance-optimization-hyper-v-replica.md
@@ -90,7 +90,7 @@ Input Interpretation:
 
 Default value: This name is not created by default under the Replication registry node. Administrators would need to manually create a DWORD under the following registry key and set the corresponding value.
 
-`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\Virtualization\Replication`
+`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Replication`
 
 > [!Note]
 > If the value is not present or set to 0, it indicates that the replica server will process 4 VHDs in parallel per VM.


### PR DESCRIPTION
a few typos found in some registry paths.
- `HKEY_*\Software\Microsoft\WindowsNT\` -> `HKEY_*\Software\Microsoft\Windows NT\`
- `HKEY_*\Software\Microsoft\Windows NT\Current Version\` -> `HKEY_*\Software\Microsoft\Windows NT\CurrentVersion\`