### PR TITLE
Added ≥ to Vista references ; Added code markdown

### DIFF
--- a/support/windows-client/deployment/analyze-sfc-program-log-file-entries.md
+++ b/support/windows-client/deployment/analyze-sfc-program-log-file-entries.md
@@ -31,7 +31,7 @@ The *SFC.exe* program performs the following operations:
 
 ## View the log file
 
-The *SFC.exe* program writes the details of each verification operation and of each repair operation to the *CBS.log* file. Each *SFC.exe* program entry in this file has an **\[SR\]** tag. The *CBS.log* file is located in the `%windir%\Logs\CBS` folder.
+The *SFC.exe* program writes the details of each verification operation and of each repair operation to the *CBS.log* file. Each *SFC.exe* program entry in this file has an **\[SR\]** tag. The *CBS.log* file is located in the *%windir%\Logs\CBS* folder.
 
 > [!NOTE]
 > The Windows Modules Installer service also writes to this log file. (The Windows Modules Installer service installs optional features, updates, and service packs.)

--- a/support/windows-client/deployment/analyze-sfc-program-log-file-entries.md
+++ b/support/windows-client/deployment/analyze-sfc-program-log-file-entries.md
@@ -1,7 +1,7 @@
 ---
 title: Analyze log file entries that SFC.exe generates
 description: Describes how to use the SFC.exe program to help diagnose problems that are caused by missing or damaged operating system files.
-ms.date: 09/24/2020
+ms.date: 05/31/2021
 author: Deland-Han
 ms.author: delhan
 manager: dscontentpm
@@ -13,33 +13,30 @@ ms.reviewer: kaushika
 ms.prod-support-area-path: Servicing
 ms.technology: windows-client-deployment
 ---
-# Analyze the log file entries that `SFC.exe` generates in Windows ≥Vista
+# Analyze the log file entries that *SFC.exe* generates in Windows
 
-This article describes how to analyze the log files that the Microsoft Windows Resource Checker (SFC.exe) program generates in Windows ≥Vista.
+This article describes how to analyze the log files that the Microsoft Windows Resource Checker (*SFC.exe*) program generates in Windows.
 
-_Applies to:_ &nbsp; Windows ≥Vista  
+_Applies to:_ &nbsp; Windows Vista and later versions  
 _Original KB number:_ &nbsp; 928228
-
-> [!NOTE]
-> Support for Windows Vista without any service packs installed ended on April 13, 2010. To continue receiving security updates for Windows, make sure you're running Windows Vista with Service Pack 2 (SP2). For more information, see [Support is ending for some versions of Windows](https://support.microsoft.com/help/14223/windows-xp-end-of-support).
 
 ## Overview
 
-You can use the `SFC.exe` program to help you troubleshoot crashes that occur in the user mode part of Windows ≥Vista. These crashes may be related to missing or damaged operating system files.
+You can use the *SFC.exe* program to help you troubleshoot crashes that occur in the user mode part of Windows. These crashes may be related to missing or damaged operating system files.
 
-The `SFC.exe` program performs the following operations:
+The *SFC.exe* program performs the following operations:
 
 - It verifies that non-configurable Windows system files have not changed. Also, it verifies that these files match the operating system's definition of which files are expected to be installed on the computer.
 - It repairs non-configurable Windows system files, when it is possible.
 
 ## View the log file
 
-The `SFC.exe` program writes the details of each verification operation and of each repair operation to the `CBS.log` file. Each `SFC.exe` program entry in this file has an **[SR]** tag. The `CBS.log` file is located in the `%windir%\Logs\CBS` folder.
+The *SFC.exe* program writes the details of each verification operation and of each repair operation to the *CBS.log* file. Each *SFC.exe* program entry in this file has an **\[SR\]** tag. The *CBS.log* file is located in the `%windir%\Logs\CBS` folder.
 
 > [!NOTE]
 > The Windows Modules Installer service also writes to this log file. (The Windows Modules Installer service installs optional features, updates, and service packs.)
 
-You can search for **[SR]** tags to help locate `SFC.exe` program entries. To perform this kind of search and to redirect the results to a text file, follow these steps:
+You can search for **\[SR\]** tags to help locate *SFC.exe* program entries. To perform this kind of search and to redirect the results to a text file, follow these steps:
 
 1. Click **Start**, type *cmd* in the **Start Search** box, right-click **cmd** in the **Programs** list, and then click **Run as administrator**.
     If you are prompted for an administrator password or for a confirmation, type your password, or click **Continue**.
@@ -49,15 +46,15 @@ You can search for **[SR]** tags to help locate `SFC.exe` program entries. To pe
     findstr /c:"[SR]" %windir%\logs\cbs\cbs.log >sfcdetails.txt
     ```
 
-The Sfcdetails.txt file includes the entries that are logged every time that the `SFC.exe` program runs on the computer.
+The Sfcdetails.txt file includes the entries that are logged every time that the *SFC.exe* program runs on the computer.
 
 ## Interpret the log file entries
 
-The `SFC.exe` program verifies files in groups of 100. Therefore, there will be many groups of `SFC.exe` program entries. Each entry has the following format:
+The *SFC.exe* program verifies files in groups of 100. Therefore, there will be many groups of *SFC.exe* program entries. Each entry has the following format:
 
 **date** **time** **entry_type details**
 
-The following sample excerpt from a `CBS.log` file shows that the `SFC.exe` program did not identify any problems with the Windows system files:
+The following sample excerpt from a *CBS.log* file shows that the *SFC.exe* program did not identify any problems with the Windows system files:
 
 ```output
 <date> <time>, Info CSI 00000006 [SR] Verifying 100 (0x00000064) components  
@@ -74,7 +71,7 @@ The following sample excerpt from a `CBS.log` file shows that the `SFC.exe` prog
 <date> <time>, Info CSI 00000011 [SR] Verify complete
 ```
 
-The following sample excerpt from a `CBS.log` file shows that the `SFC.exe` program has identified problems with the Windows system files:
+The following sample excerpt from a *CBS.log* file shows that the *SFC.exe* program has identified problems with the Windows system files:
 
 ```output
 <date> <time>, Info CSI 00000006 [SR] Verifying 100 (0x00000064) components  
@@ -86,9 +83,9 @@ The following sample excerpt from a `CBS.log` file shows that the `SFC.exe` prog
 ```
 
 > [!NOTE]
-> Although the log file entry states that the `SFC.exe` program is repairing the changed file, no actual repair operation occurs when a file is verified.
+> Although the log file entry states that the *SFC.exe* program is repairing the changed file, no actual repair operation occurs when a file is verified.
 
-The following list describes other messages that may be logged in the `SFC.exe` program entries of the `CBS.log` file after verification is completed.
+The following list describes other messages that may be logged in the *SFC.exe* program entries of the *CBS.log* file after verification is completed.
 
 - Entry 1: Cannot repair member file **file details**. For example:
 
@@ -96,7 +93,7 @@ The following list describes other messages that may be logged in the `SFC.exe` 
   Cannot repair member file [l:14{7}]"url.dll" of Microsoft-Windows-IE-WinsockAutodialStub, Version = 6.0.5752.0, pA = PROCESSOR_ARCHITECTURE_INTEL (0), Culture neutral, VersionScope = 1 nonSxS, PublicKeyToken = {l:8 b:31bf3856ad364e35}, Type neutral, TypeN
   ```
 
-    This entry indicates that the file content does not match the operating system definition for the file. In this situation, the `SFC.exe` program cannot repair the file.
+  This entry indicates that the file content does not match the operating system definition for the file. In this situation, the *SFC.exe* program cannot repair the file.
 
 - Entry 2: Repaired file **file details** by copying from backup. For example:
 
@@ -104,7 +101,7 @@ The following list describes other messages that may be logged in the `SFC.exe` 
   Repaired file \SystemRoot\WinSxS\Manifests\[ml:24{12},l:18{9}]"netnb.inf" by copying from backup
   ```
 
-    This entry indicates that a problem exists with a file. The `SFC.exe` program can repair this file by copying a version from a private system store backup.
+  This entry indicates that a problem exists with a file. The *SFC.exe* program can repair this file by copying a version from a private system store backup.
 
 - Entry 3: Repairing corrupted file **file details** from store. For example:
 
@@ -112,4 +109,4 @@ The following list describes other messages that may be logged in the `SFC.exe` 
   Repairing corrupted file [ml:520{260},l:36{18}]"??\C:\Windows\inf"[l:18{9}]"netnb.inf" from store
   ```
 
-    This entry indicates that a problem exists with a file. The `SFC.exe` program can repair this file by copying a version from the system store.
+  This entry indicates that a problem exists with a file. The *SFC.exe* program can repair this file by copying a version from the system store.

--- a/support/windows-client/deployment/analyze-sfc-program-log-file-entries.md
+++ b/support/windows-client/deployment/analyze-sfc-program-log-file-entries.md
@@ -13,11 +13,11 @@ ms.reviewer: kaushika
 ms.prod-support-area-path: Servicing
 ms.technology: windows-client-deployment
 ---
-# Analyze the log file entries that SFC.exe generates in Windows Vista
+# Analyze the log file entries that `SFC.exe` generates in Windows ≥Vista
 
-This article describes how to analyze the log files that the Microsoft Windows Resource Checker (SFC.exe) program generates in Windows Vista.
+This article describes how to analyze the log files that the Microsoft Windows Resource Checker (SFC.exe) program generates in Windows ≥Vista.
 
-_Applies to:_ &nbsp; Windows Vista  
+_Applies to:_ &nbsp; Windows ≥Vista  
 _Original KB number:_ &nbsp; 928228
 
 > [!NOTE]
@@ -25,21 +25,21 @@ _Original KB number:_ &nbsp; 928228
 
 ## Overview
 
-You can use the SFC.exe program to help you troubleshoot crashes that occur in the user mode part of Windows Vista. These crashes may be related to missing or damaged operating system files.
+You can use the `SFC.exe` program to help you troubleshoot crashes that occur in the user mode part of Windows ≥Vista. These crashes may be related to missing or damaged operating system files.
 
-The SFC.exe program performs the following operations:
+The `SFC.exe` program performs the following operations:
 
-- It verifies that non-configurable Windows Vista system files have not changed. Also, it verifies that these files match the operating system's definition of which files are expected to be installed on the computer.
-- It repairs non-configurable Windows Vista system files, when it is possible.
+- It verifies that non-configurable Windows system files have not changed. Also, it verifies that these files match the operating system's definition of which files are expected to be installed on the computer.
+- It repairs non-configurable Windows system files, when it is possible.
 
 ## View the log file
 
-The SFC.exe program writes the details of each verification operation and of each repair operation to the CBS.log file. Each SFC.exe program entry in this file has an **[SR]** tag. The CBS.log file is located in the `%windir%\Logs\CBS` folder.
+The `SFC.exe` program writes the details of each verification operation and of each repair operation to the `CBS.log` file. Each `SFC.exe` program entry in this file has an **[SR]** tag. The `CBS.log` file is located in the `%windir%\Logs\CBS` folder.
 
 > [!NOTE]
 > The Windows Modules Installer service also writes to this log file. (The Windows Modules Installer service installs optional features, updates, and service packs.)
 
-You can search for **[SR]** tags to help locate SFC.exe program entries. To perform this kind of search and to redirect the results to a text file, follow these steps:
+You can search for **[SR]** tags to help locate `SFC.exe` program entries. To perform this kind of search and to redirect the results to a text file, follow these steps:
 
 1. Click **Start**, type *cmd* in the **Start Search** box, right-click **cmd** in the **Programs** list, and then click **Run as administrator**.
     If you are prompted for an administrator password or for a confirmation, type your password, or click **Continue**.
@@ -49,15 +49,15 @@ You can search for **[SR]** tags to help locate SFC.exe program entries. To perf
     findstr /c:"[SR]" %windir%\logs\cbs\cbs.log >sfcdetails.txt
     ```
 
-The Sfcdetails.txt file includes the entries that are logged every time that the SFC.exe program runs on the computer.
+The Sfcdetails.txt file includes the entries that are logged every time that the `SFC.exe` program runs on the computer.
 
 ## Interpret the log file entries
 
-The SFC.exe program verifies files in groups of 100. Therefore, there will be many groups of SFC.exe program entries. Each entry has the following format:
+The `SFC.exe` program verifies files in groups of 100. Therefore, there will be many groups of `SFC.exe` program entries. Each entry has the following format:
 
 **date** **time** **entry_type details**
 
-The following sample excerpt from a CBS.log file shows that the SFC.exe program did not identify any problems with the Windows Vista system files:
+The following sample excerpt from a `CBS.log` file shows that the `SFC.exe` program did not identify any problems with the Windows system files:
 
 ```output
 <date> <time>, Info CSI 00000006 [SR] Verifying 100 (0x00000064) components  
@@ -74,7 +74,7 @@ The following sample excerpt from a CBS.log file shows that the SFC.exe program 
 <date> <time>, Info CSI 00000011 [SR] Verify complete
 ```
 
-The following sample excerpt from a CBS.log file shows that the SFC.exe program has identified problems with the Windows Vista system files:
+The following sample excerpt from a `CBS.log` file shows that the `SFC.exe` program has identified problems with the Windows system files:
 
 ```output
 <date> <time>, Info CSI 00000006 [SR] Verifying 100 (0x00000064) components  
@@ -86,9 +86,9 @@ The following sample excerpt from a CBS.log file shows that the SFC.exe program 
 ```
 
 > [!NOTE]
-> Although the log file entry states that the SFC.exe program is repairing the changed file, no actual repair operation occurs when a file is verified.
+> Although the log file entry states that the `SFC.exe` program is repairing the changed file, no actual repair operation occurs when a file is verified.
 
-The following list describes other messages that may be logged in the SFC.exe program entries of the CBS.log file after verification is completed.
+The following list describes other messages that may be logged in the `SFC.exe` program entries of the `CBS.log` file after verification is completed.
 
 - Entry 1: Cannot repair member file **file details**. For example:
 
@@ -96,7 +96,7 @@ The following list describes other messages that may be logged in the SFC.exe pr
   Cannot repair member file [l:14{7}]"url.dll" of Microsoft-Windows-IE-WinsockAutodialStub, Version = 6.0.5752.0, pA = PROCESSOR_ARCHITECTURE_INTEL (0), Culture neutral, VersionScope = 1 nonSxS, PublicKeyToken = {l:8 b:31bf3856ad364e35}, Type neutral, TypeN
   ```
 
-    This entry indicates that the file content does not match the operating system definition for the file. In this situation, the SFC.exe program cannot repair the file.
+    This entry indicates that the file content does not match the operating system definition for the file. In this situation, the `SFC.exe` program cannot repair the file.
 
 - Entry 2: Repaired file **file details** by copying from backup. For example:
 
@@ -104,7 +104,7 @@ The following list describes other messages that may be logged in the SFC.exe pr
   Repaired file \SystemRoot\WinSxS\Manifests\[ml:24{12},l:18{9}]"netnb.inf" by copying from backup
   ```
 
-    This entry indicates that a problem exists with a file. The SFC.exe program can repair this file by copying a version from a private system store backup.
+    This entry indicates that a problem exists with a file. The `SFC.exe` program can repair this file by copying a version from a private system store backup.
 
 - Entry 3: Repairing corrupted file **file details** from store. For example:
 
@@ -112,4 +112,4 @@ The following list describes other messages that may be logged in the SFC.exe pr
   Repairing corrupted file [ml:520{260},l:36{18}]"??\C:\Windows\inf"[l:18{9}]"netnb.inf" from store
   ```
 
-    This entry indicates that a problem exists with a file. The SFC.exe program can repair this file by copying a version from the system store.
+    This entry indicates that a problem exists with a file. The `SFC.exe` program can repair this file by copying a version from the system store.


### PR DESCRIPTION
- This applies to all Windows versions over Vista:
  - Not having this notated can make users believe the man page isn't up-to-date/accurate
  - Where applicable, I added the `≥` symbol [greater than/equal to] and removed Vista references where it made sense

- Monospaced code markdown should be used for all monospaced code, else web translators will often make the content gibberish  ([example](https://imgur.com/a/5K8tmRo)):
  - Web translators don't modify text marked as monospaced code
  - I didn't add backticks to the two `SFC.exe` mentions in the table, as they didn't render correctly in the GitHub preview and am unsure if the same would be true for Microsoft Docs