### PR TITLE
Update cannot-change-state-menu-item.md

### DIFF
--- a/support/cpp/cannot-change-state-menu-item.md
+++ b/support/cpp/cannot-change-state-menu-item.md
@@ -56,6 +56,12 @@ Use the following steps to resolve this problem:
 ```cpp
 void CTestDlg::OnInitMenuPopup(CMenu *pPopupMenu, UINT nIndex,BOOL bSysMenu)
 {
+    // Make sure this is actually a menu. When clicking the program icon
+    // in the window title bar this function will trigger and pPopupMenu 
+    // will NOT be a menu.
+    if (!IsMenu(pPopupMenu->m_hMenu))
+		return;
+        
     ASSERT(pPopupMenu != NULL);
     // Check the enabled state of various menu items.
 


### PR DESCRIPTION
Added a piece of code in step 2 of the resolution. Without this any program that uses this code will crash if the user clicks on the program icon in the window title bar.