### PR TITLE
Added apostrophe to example 3 that was missing

### DIFF
--- a/support/windows-server/backup-and-storage/database-backup-error-3266-3013.md
+++ b/support/windows-server/backup-and-storage/database-backup-error-3266-3013.md
@@ -72,7 +72,7 @@ RESTORE HEADERONLY FROM DISK='C:\MyDatabase.bak'
 Each backup set has one entry in the output. To indicate a specific backup set, use this code:
 
 ```sql
-RESTORE DATABASE mydatabase FROM DISK='C:\MyDatabase.bak WITH FILE = FileNumber
+RESTORE DATABASE mydatabase FROM DISK='C:\MyDatabase.bak' WITH FILE = FileNumber
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The example was missing a tick mark after the file name path and we added it to it