### PR TITLE
Update wildcard-matching-rule-fails-with-event-10303.md

### DIFF
--- a/support/system-center/scom/wildcard-matching-rule-fails-with-event-10303.md
+++ b/support/system-center/scom/wildcard-matching-rule-fails-with-event-10303.md
@@ -48,7 +48,7 @@ To resolve this problem, follow these steps:
 
 1. Create the following registry subkey:
 
-    `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft Operations Manager\v3\Modules\Global\ExpressionFilter`
+    `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft Operations Manager\3.0\Modules\Global\ExpressionFilter`
 
 2. Under this subkey, create a DWORD value.
 3. Type the `MaxExpressionDepth` name for the DWORD value.


### PR DESCRIPTION
Fix typo with:
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft Operations Manager\v3\Modules\Global\ExpressionFilter

to:
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft Operations Manager\3.0\Modules\Global\ExpressionFilter