### PR TITLE
Alter sp_help_revlogin to use QUOTENAME()

### DIFF
--- a/support/sql/security/transfer-logins-passwords-between-instances.md
+++ b/support/sql/security/transfer-logins-passwords-between-instances.md
@@ -150,7 +150,7 @@ To transfer the logins, use one of the following methods, as appropriate for you
       SELECT @is_policy_checked = CASE is_policy_checked WHEN 1 THEN 'ON' WHEN 0 THEN 'OFF' ELSE NULL END FROM sys.sql_logins WHERE name = @name
       SELECT @is_expiration_checked = CASE is_expiration_checked WHEN 1 THEN 'ON' WHEN 0 THEN 'OFF' ELSE NULL END FROM sys.sql_logins WHERE name = @name
 
-      SET @tmpstr = 'CREATE LOGIN ' + QUOTENAME( @name ) + ' WITH PASSWORD = ' + @PWD_string + ' HASHED, SID = ' + @SID_string + ', DEFAULT_DATABASE = [' + @defaultdb + ']'
+      SET @tmpstr = 'CREATE LOGIN ' + QUOTENAME( @name ) + ' WITH PASSWORD = ' + @PWD_string + ' HASHED, SID = ' + @SID_string + ', DEFAULT_DATABASE = ' + QUOTENAME(@defaultdb) 
 
       IF ( @is_policy_checked IS NOT NULL )
       BEGIN


### PR DESCRIPTION
Changing to use QUOTENAME() in sp_help_revlogin to ensure database names are properly escaped. Ex, if the database name includes a `]` character