### PR TITLE
Remove productType from wmi filter

### DIFF
--- a/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
+++ b/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
@@ -99,7 +99,7 @@ For more information about how to create GPOs, see [Create a Group Policy Object
 1. In **Query**, enter the following query string:
 
    ```sql
-   SELECT version.producttype from Win32_OperatingSystem WHERE Version = <VersionNumber>
+   SELECT version from Win32_OperatingSystem WHERE Version = <VersionNumber>
    ```
 
    > [!IMPORTANT]  

--- a/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
+++ b/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
@@ -99,7 +99,7 @@ For more information about how to create GPOs, see [Create a Group Policy Object
 1. In **Query**, enter the following query string:
 
    ```sql
-   SELECT version from Win32_OperatingSystem WHERE Version = <VersionNumber>
+   SELECT version, producttype from Win32_OperatingSystem WHERE Version = <VersionNumber>
    ```
 
    > [!IMPORTANT]  


### PR DESCRIPTION
The dot between version and productType should either be a comma or be removed from the query to run.