### PR TITLE
Update lt2p-ipsec-ras-vpn-connections-fail.md

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -849,6 +849,11 @@
       "source_path": "support/windows-client/deployment/compute-md5sha-1-cryptographic-hash-value.md",
       "redirect_url": "https://support.microsoft.com/topic/d92a713f-d793-7bd8-b0a4-4db811e29559",
       "redirect_document_id": false
+    },
+    {
+      "source_path": "support/windows-server/networking/lt2p-ipsec-ras-vpn-connections-fail",
+      "redirect_url": "support/windows-server/networking/rras-vpn-connections-fail-ms-chapv2-authentication.md",
+      "redirect_document_id": true
     }
   ]
 }

--- a/support/windows-server/networking/lt2p-ipsec-ras-vpn-connections-fail.md
+++ b/support/windows-server/networking/lt2p-ipsec-ras-vpn-connections-fail.md
@@ -1,6 +1,6 @@
 ---
-title: LT2P/IPsec RAS VPN connections fail
-description: L2TP/IPsec VPN connections to a Windows RAS Server fail when using the MS-CHAPv2 authentication. Provides a resolution.
+title: VPN connections fail
+description: VPN connections to a Windows RAS Server fail when using the MS-CHAPv2 authentication. Provides a resolution.
 ms.date: 09/08/2020
 author: Deland-Han
 ms.author: delhan
@@ -13,16 +13,16 @@ ms.reviewer: kaushika, BrCaton
 ms.prod-support-area-path: Remote access
 ms.technology: networking
 ---
-# LT2P/IPsec RAS VPN connections fail when using MS-CHAPv2
+# VPN connections fail when using MS-CHAPv2
 
-This article resolves the issue that L2TP/IPsec VPN connections to a Windows RAS Server fail when using the MS-CHAPv2 authentication.
+This article resolves the issue that VPN connections to a Windows RRAS Server fail when using the MS-CHAPv2 authentication.
 
 _Applies to:_ &nbsp; Windows Server 2012 R2  
 _Original KB number:_ &nbsp; 2811487
 
 ## Symptoms
 
-L2TP/IPsec VPN connections to a Windows RAS Server fail when using the MS-CHAPv2 authentication method. Other symptoms include the end user may receive an error message like this one:
+VPN connections to a Windows RRAS Server fail when using the MS-CHAPv2 authentication method. Other symptoms include the end user may receive an error message like this one:
 
 > error 691 "The remote connection was denied because the user name and password combination you provided is not recognized, or the selected authentication protocol is not permitted on the remote access server.
 

--- a/support/windows-server/networking/rras-vpn-connections-fail-ms-chapv2-authentication.md
+++ b/support/windows-server/networking/rras-vpn-connections-fail-ms-chapv2-authentication.md
@@ -1,5 +1,5 @@
 ---
-title: VPN connections fail
+title: VPN connections fail when using the MS-CHAPv2 authentication
 description: VPN connections to a Windows RAS Server fail when using the MS-CHAPv2 authentication. Provides a resolution.
 ms.date: 09/08/2020
 author: Deland-Han

--- a/support/windows-server/networking/rras-vpn-connections-fail-ms-chapv2-authentication.md
+++ b/support/windows-server/networking/rras-vpn-connections-fail-ms-chapv2-authentication.md
@@ -32,7 +32,7 @@ Additionally, the domain user's bad password count can increment, resulting in a
 
 This issue can occur when the [LmCompatibilityLevel](/previous-versions/windows/it-pro/windows-2000-server/cc960646(v=technet.10)) settings on the authenticating DC have been modified from the defaults.
 
-`HKLM\SYSTEM\CurrentControlSet\Control\Lsa\LmCompatibilityLevel`
+`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\LmCompatibilityLevel`
 
 For example, when you set this value to **5** (Send NTLMv2 response only. Refuse LM & NTLM), the DC won't accept any requests that use NTLM authentication. When MS-CHAP or MS-CHAPv2 are configured, RAS in Windows Server 2008 R2 will default to NTLM to hash the password. Because the DC only accepts NTLMv2, the request will be denied.
 

--- a/support/windows-server/toc.yml
+++ b/support/windows-server/toc.yml
@@ -1649,7 +1649,7 @@
     - name: L2TP VPN fails with error 787
       href: ./networking/l2tp-vpn-fails-with-error-787.md
     - name: LT2P/IPsec RAS VPN connections fail
-      href: ./networking/lt2p-ipsec-ras-vpn-connections-fail.md
+      href: ./networking/rras-vpn-connections-fail-ms-chapv2-authentication.md
     - name: Set Up Routing and Remote Access for an Intranet
       href: ./networking/set-up-routing-remote-access-intranet.md
     - name: The Routing and Remote Access service doesn't start


### PR DESCRIPTION
The issue is not related to L2TP or IPsec but only MSCHAP(v2) that can be used with any other VPN protocol type, too. Like IKEv2, SSTP, PPTP.
I'd like to remove references to L2TP and IPsec because they might confuse users of other VPN protocols running into the same issue.
The link should also be updated to contain L2TP and IPsec no longer - I don't know how this works
https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/**lt2p-ipsec**-ras-vpn-connections-fail
