### PR TITLE
Added missing value of 5 for ClientHealthStatus

### DIFF
--- a/support/mem/intune/troubleshoot-co-management-bootstrap.md
+++ b/support/mem/intune/troubleshoot-co-management-bootstrap.md
@@ -156,7 +156,7 @@ The following are possible values of `ClientHealthStatus`:
 
 - **1**: Client installed
 - **2**: Client registered
-- **5**: Client installed but has not run Health Evaluation yet
+- **5**: Client installed, but hasn't run Health Evaluation yet
 - **7**: Client healthy
 - **8**: Client install or upgrade error
 - **16**: Communication error in management point

--- a/support/mem/intune/troubleshoot-co-management-bootstrap.md
+++ b/support/mem/intune/troubleshoot-co-management-bootstrap.md
@@ -156,6 +156,7 @@ The following are possible values of `ClientHealthStatus`:
 
 - **1**: Client installed
 - **2**: Client registered
+- **5**: Client installed but has not run Health Evaluation yet
 - **7**: Client healthy
 - **8**: Client install or upgrade error
 - **16**: Communication error in management point


### PR DESCRIPTION
Under "Configuration Manager agent state is unhealthy in Intune" we list several possible values for ClientHealthStatus. However, we don't list 5 as being an option, but this is the value ClientHealthStatus will be set to on a newly installed or reinstalled ConfigMgr client, before it has run the daily scheduled task “Configuration Manager Health Evaluation” for the first time.

After it runs, CcmEval.log will note the value has been updated to 7 with a log in the entry: "Updating MDM_ConfigSetting.ClientHealthStatus with value 7"