### PR TITLE
Update Article to add another known solution for Event 76 Auto MDM Enroll: Failed (Unknown Win32 Error code: 0x8018002b)

### DIFF
--- a/support/mem/intune/troubleshoot-windows-enrollment-errors.md
+++ b/support/mem/intune/troubleshoot-windows-enrollment-errors.md
@@ -249,6 +249,8 @@ If the UPN contains an unverified or non-routable domain, follow these steps:
     Import-Module ADSync
     Start-ADSyncSyncCycle -PolicyType Delta
     ```
+> [!NOTE]
+> Another alternative for this issue would be [Configuring Alternate Login ID](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configuring-alternate-login-id). Make sure to review the Alternate login Id article before making a decision to implement it.
 
 If **MDM user scope** is set to **None**, follow these steps:
 

--- a/support/mem/intune/troubleshoot-windows-enrollment-errors.md
+++ b/support/mem/intune/troubleshoot-windows-enrollment-errors.md
@@ -250,7 +250,7 @@ If the UPN contains an unverified or non-routable domain, follow these steps:
     Start-ADSyncSyncCycle -PolicyType Delta
     ```
 > [!NOTE]
-> Another alternative for this issue would be [Configuring Alternate Login ID](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configuring-alternate-login-id). Make sure to review the Alternate login Id article before making a decision to implement it.
+> Another solution to this issue is [Configuring Alternate Login ID](/windows-server/identity/ad-fs/operations/configuring-alternate-login-id). Be sure to review the article before you decide to implement this solution.
 
 If **MDM user scope** is set to **None**, follow these steps:
 


### PR DESCRIPTION
Adding a solution of one of the issues listed, 

> [!NOTE]
> Another alternative for this issue would be [Configuring Alternate Login ID](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configuring-alternate-login-id). Make sure to review the Alternate login Id article before making a decision to implement it.