### PR TITLE
Update serial-console-grub-single-user-mode.md

### DIFF
--- a/support/azure/virtual-machines/serial-console-grub-single-user-mode.md
+++ b/support/azure/virtual-machines/serial-console-grub-single-user-mode.md
@@ -134,6 +134,7 @@ If you didn't enable the root user by following the earlier instructions, you ca
 1. In the shell, enter `mount -o remount,rw /sysroot` to remount the root file system with read/write permissions.
 1. After you boot into single-user mode, enter `chroot /sysroot` to switch into the `sysroot` jail.
 1. You're now at root. You can reset your root password by entering `passwd` and then use the preceding instructions to enter single-user mode.
+1. After changing the password. You need to relabel. Usually RHEL systems has SELinux Enforcing and protects the OS from any changes. To do that run touch `/.autorelabel`.
 1. After you're done, enter `reboot -f` to reboot.
 
 ![Animated image showing a command-line interface. The user selects a server, locates the end of the kernel line, and enters the specified commands.](./media/serial-console-grub-single-user-mode/virtual-machine-linux-serial-console-rhel-emergency-mount-no-root.gif)


### PR DESCRIPTION
 After changing the password. You need to relabel. Usually RHEL systems has SELinux Enforcing and protects the OS from any changes. To do that run touch `/.autorelabel`.
After point 8 and before point 9. on the  Enter single-user mode without root account enabled in RHEL
https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/serial-console-grub-single-user-mode#enter-single-user-mode-without-root-account-enabled-in-rhel