### PR TITLE
Add note for GP Central Store

### DIFF
--- a/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
+++ b/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
@@ -81,6 +81,8 @@ To apply a KIR policy definition to devices that belong to a hybrid Azure AD or 
 1. Check the KIR release information or the known issues lists to identify which operating system versions you have to update.  
 1. Download the KIR policy definition .msi files that you require to update to the computer that you use to manage Group Policy for your domain.
 1. Run the .msi files. This action installs the KIR policy definition in the Administrative Template.  
+[!NOTE]  
+   > Policy definitions are installed to C:\Windows\PolicyDefinitions. If you have implemented the Group Policy [Central Store](https://docs.microsoft.com/en-us/troubleshoot/windows-client/group-policy/create-and-manage-central-store#the-central-store), you must copy the .admx and .adml files to the Central Store.
 
 ### <a id="gpo"></a>2. Create a GPO
 

--- a/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
+++ b/support/windows-client/group-policy/use-group-policy-to-deploy-known-issue-rollback.md
@@ -81,8 +81,8 @@ To apply a KIR policy definition to devices that belong to a hybrid Azure AD or 
 1. Check the KIR release information or the known issues lists to identify which operating system versions you have to update.  
 1. Download the KIR policy definition .msi files that you require to update to the computer that you use to manage Group Policy for your domain.
 1. Run the .msi files. This action installs the KIR policy definition in the Administrative Template.  
-[!NOTE]  
-   > Policy definitions are installed to C:\Windows\PolicyDefinitions. If you have implemented the Group Policy [Central Store](https://docs.microsoft.com/en-us/troubleshoot/windows-client/group-policy/create-and-manage-central-store#the-central-store), you must copy the .admx and .adml files to the Central Store.
+   > [!NOTE]  
+   > Policy definitions are installed in the *C:\Windows\PolicyDefinitions* folder. If you have implemented the Group Policy [Central Store](create-and-manage-central-store.md#the-central-store), you must copy the .admx and .adml files to the Central Store.
 
 ### <a id="gpo"></a>2. Create a GPO
 


### PR DESCRIPTION
The Group Policy Central Store is recommended to reduce SYSVOL bloat. This change proposes clarifying implementation in a domain scenario with Central Store enabled