### PR TITLE
Troubleshooter VMs with GuestAgent_XXX.XXX.XX folder absent.

### DIFF
--- a/support/azure/virtual-machines/install-vm-agent-offline.md
+++ b/support/azure/virtual-machines/install-vm-agent-offline.md
@@ -83,7 +83,7 @@ Use the following steps to install the VM Agent in offline mode.
 
         1.	On the OS disk that you attached, create a folder named WindowsAzure in the root path.
 
-        2.	Go to C:\WindowsAzure on the troubleshooter VM, look for any folder with the name C:\WindowsAzure\GuestAgent_X.X.XXXX.XXX. Copy the GuestAgent folder that has latest version number from C:\WindowsAzure to the WindowsAzure folder in the attached OS disk. If you are not sure which folder should be copied, copy all GuestAgent folders. The following image shows an example of the GuestAgent folder that is copied to the attached OS disk.
+        2.	Go to C:\WindowsAzure on the troubleshooter VM, look for any folder with the name C:\WindowsAzure\GuestAgent_X.X.XXXX.XXX. Copy the GuestAgent folder that has latest version number from C:\WindowsAzure to the WindowsAzure folder in the attached OS disk. If you are not sure which folder should be copied, copy all GuestAgent folders. The following image shows an example of the GuestAgent folder that is copied to the attached OS disk. The troubleshooter VM may also contains a C:\WindowsAzure\Packages folder if GuestAgent_X.X.XXXX.XXX folder is absent. Check for the imagePath of WindowsAzureGuestAgent registry subkey for the accurate path.
 
              ![Copy GuestAgent folder](./media/install-vm-agent-offline/copy-files.png)
 


### PR DESCRIPTION
Troubleshooter VMs with GuestAgent_XXX.XXX.XX folder absent have Packages folder instead of it. Adding additional check to detect Guest Agent path