### PR TITLE
removing erroneous space in step 5 of NSLookup

### DIFF
--- a/support/windows-server/networking/verify-srv-dns-records-have-been-created.md
+++ b/support/windows-server/networking/verify-srv-dns-records-have-been-created.md
@@ -56,7 +56,7 @@ To use `Nslookup` to verify the SRV records, follow these steps:
 2. In the **Open** box, type `cmd`.
 3. Type `nslookup`, and then press ENTER.
 4. Type `set type=all`, and then press ENTER.
-5. Type `_ldap._tcp.dc._msdcs. Domain_Name`, where \<Domain_Name> is the name of your domain, and then press ENTER.
+5. Type `_ldap._tcp.dc._msdcs.Domain_Name`, where \<Domain_Name> is the name of your domain, and then press ENTER.
 
 `Nslookup` returns one or more SRV service location records that appear in the following format, where \<Server_Name> is the host name of a domain controller, and where \<Domain_Name> is the domain where the domain controller belongs to, and \<Server_IP_Address> is the domain controller's Internet Protocol (IP) address:
 


### PR DESCRIPTION
Thanks a ton for this article!  While using it to triage something in one of the environments I'm responsible for, I noticed I was getting erroneous output due to the space in the command.  Just thought I'd try to correct for the next person who needs to use it.