### PR TITLE
InstallationState 2 for Win32Apps

### DIFF
--- a/support/mem/intune/understand-troubleshoot-esp.md
+++ b/support/mem/intune/understand-troubleshoot-esp.md
@@ -269,7 +269,7 @@ This subkey contains the following subkeys:
   Available values for `InstallationState` are:
 
   - 1 (NotInstalled)
-  - 2 (NotRequired)
+  - 2 (InProgress)
   - 3 (Completed)
   - 4 (Error)
 


### PR DESCRIPTION
InstallationState 2 for Win32Apps means "InProgress", not "NotRequired", as shown in an IntuneManagementExtension.log:

[Win32App] Getting Win32AppState for Win32App_<GUID>
[Win32App] Got InstanceID: Win32App_<GUID>, installationStateString: 2
[Win32App] Got installationState: InProgress