### PR TITLE
Step 4 - retry content replication - will never work

### DIFF
--- a/support/mem/configmgr/understand-troubleshoot-updates-servicing.md
+++ b/support/mem/configmgr/understand-troubleshoot-updates-servicing.md
@@ -467,15 +467,29 @@ To do so, compare the following folders:
 
 To do so, follow these steps:
 
-1. Open WBEMTEST.
-2. Connect to `root\sms\site_<SiteCode>`, and select **Execute Method**.
-3. Enter `SMS_CM_UpdatePackages` in **Object Path**, and select **OK**.
-4. Select **RetryContentReplication** from **Method**, and select **Edit in Parameters**.
-5. Select the **ForceRetry** property, and select **Edit Property**.
-6. In **Value**, select **Not Null**, and enter *1*.
-7. Select **Save Property** > **Save Object**.
-8. Select **Execute!**.
-9. Review Distmgr.log to check whether the package replicates successfully.
+1. Open PowerShell command line
+2. Run the following command: 
+```Powershell
+(gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
+```
+3. The output should look like below. If it's not - please verify the command line for typos.
+
+```Powershell
+__GENUS          : 2
+__CLASS          : __PARAMETERS
+__SUPERCLASS     : 
+__DYNASTY        : __PARAMETERS
+__RELPATH        : 
+__PROPERTY_COUNT : 1
+__DERIVATION     : {}
+__SERVER         : 
+__NAMESPACE      : 
+__PATH           : 
+ReturnValue      : 0
+PSComputerName   : 
+```
+    
+4. Review Distmgr.log to check whether the package replicates successfully.
 
 ### Issue 1: Error "Failed to calculate hash SMS_HIERARCHY_MANAGER"
 
@@ -822,8 +836,8 @@ To fix this issue, follow these steps:
 
 If there's a failure during content replication, retry the replication by running the following command:
 
-```console
-WMIC /namespace:\\root\sms\site_<site code> path SMS_CM_UpdatePackages WHERE PackageGuid="PackageGUID" CALL RetryContentReplication 1 /NOINTERACTIVE
+```Powershell
+(gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
 ```
 
 It tells `HMan` to start a package notification and update thread in DistMgr to start replicating the content again. Consider that it changes the package version and copies the content to all child primary sites again.

--- a/support/mem/configmgr/understand-troubleshoot-updates-servicing.md
+++ b/support/mem/configmgr/understand-troubleshoot-updates-servicing.md
@@ -467,14 +467,14 @@ To do so, compare the following folders:
 
 To do so, follow these steps:
 
-1. Open a Windows PowerShell session.
-2. Run the following cmdlet:
+1. Start Windows PowerShell.
+2. Run the following command:
 
     ```powershell
-    (gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
+    (gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)
     ```
 
-3. The output should look like this:
+3. The output should look like this example:
 
     ```output
     __GENUS          : 2
@@ -839,7 +839,7 @@ To fix this issue, follow these steps:
 If there's a failure during content replication, retry the replication by running the following cmdlet:
 
 ```powershell
-(gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
+(gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)
 ```
 
 It tells `HMan` to start a package notification and update thread in DistMgr to start replicating the content again. Consider that it changes the package version and copies the content to all child primary sites again.

--- a/support/mem/configmgr/understand-troubleshoot-updates-servicing.md
+++ b/support/mem/configmgr/understand-troubleshoot-updates-servicing.md
@@ -467,29 +467,31 @@ To do so, compare the following folders:
 
 To do so, follow these steps:
 
-1. Open PowerShell command line
-2. Run the following command: 
-```Powershell
-(gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
-```
-3. The output should look like below. If it's not - please verify the command line for typos.
+1. Open a Windows PowerShell session.
+2. Run the following cmdlet:
 
-```Powershell
-__GENUS          : 2
-__CLASS          : __PARAMETERS
-__SUPERCLASS     : 
-__DYNASTY        : __PARAMETERS
-__RELPATH        : 
-__PROPERTY_COUNT : 1
-__DERIVATION     : {}
-__SERVER         : 
-__NAMESPACE      : 
-__PATH           : 
-ReturnValue      : 0
-PSComputerName   : 
-```
-    
-4. Review Distmgr.log to check whether the package replicates successfully.
+    ```powershell
+    (gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
+    ```
+
+3. The output should look like this:
+
+    ```output
+    __GENUS          : 2
+    __CLASS          : __PARAMETERS
+    __SUPERCLASS     : 
+    __DYNASTY        : __PARAMETERS
+    __RELPATH        : 
+    __PROPERTY_COUNT : 1
+    __DERIVATION     : {}
+    __SERVER         : 
+    __NAMESPACE      : 
+    __PATH           : 
+    ReturnValue      : 0
+    PSComputerName   : 
+    ```
+
+4. Review *Distmgr.log* to check whether the package replicates successfully.
 
 ### Issue 1: Error "Failed to calculate hash SMS_HIERARCHY_MANAGER"
 
@@ -834,9 +836,9 @@ To fix this issue, follow these steps:
 
 ### Issue 4: Content replication fails
 
-If there's a failure during content replication, retry the replication by running the following command:
+If there's a failure during content replication, retry the replication by running the following cmdlet:
 
-```Powershell
+```powershell
 (gwmi -Namespace "ROOT\SMS\site_<SITE CODE>" -query "select * from SMS_CM_UpdatePackages where PackageGuid = '<PACKAGE GUID>'").RetryContentReplication($true)"
 ```
 


### PR DESCRIPTION
Current wbemtest path doesn't include selecting the instance to run WMI method against and therefore fails with "Invalid parameter". 
Powershell code option looks preferable.