### PR TITLE
Dynamic Groups improvement update

### DIFF
--- a/support/azure/active-directory/troubleshoot-dynamic-groups.md
+++ b/support/azure/active-directory/troubleshoot-dynamic-groups.md
@@ -51,7 +51,7 @@ Existing members of the rule are removed.
 
 You don't see membership changes instantly after adding or changing a rule.
 
-- Membership evaluation is performed periodically as a background process. The duration of the process is determined by the number of users in your directory, and the size of the group is created because of the rule. Typically, directories with small numbers of users will see group membership changes within a few minutes. Directories with a large number of users can take 24 hours or longer to populate.
+- Membership evaluation is performed periodically as a background process. The duration of the process is determined by the number of users in your directory, and the size of the group is created because of the rule. Typically, directories with small numbers of users will see group membership changes within a few minutes. Directories with a large number of users can take 30 minutes or longer to populate.
 
 - Check the [membership processing status](/azure/active-directory/users-groups-roles/groups-create-rule#check-processing-status-for-a-rule) to confirm whether the process is complete. Check the last updated date on the group **Overview** page in Azure portal to confirm that the page is updated.
 


### PR DESCRIPTION
After the improvements implemented in dynamic groups, while initial population of dynamic groups might take 24 hours or longer to populate, updates to dynamic groups should take only 30min. or longer. Please reference product group documentation stating the same, here: https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/groups-troubleshooting#troubleshooting-dynamic-memberships-for-groups