### PR TITLE
Update RegEx Example to include Windows Computer DisplayName

### DIFF
--- a/support/system-center/scom/regular-expression-support.md
+++ b/support/system-center/scom/regular-expression-support.md
@@ -88,6 +88,20 @@ Search for any matches to folders located recursively under the two folder paths
 ^(\/var\/lib\/string1\/.*)|^(\/var\/lib\/string2\/.*)$
 ```
 
+### Example 4
+
+Search for any matches to Windows Computers with display names that match the following (case insensitive), (`Agent1` or `Agent2`):
+
+```perl
+^(?i)(agent1)|(?i)(agent2)$
+```
+
+Search for any matches to Windows Computers with display names that match any name containing the following (case insensitive), (`Agent`):
+
+```perl
+^(?i)(agent.*)$
+```
+
 ## Regular expressions via SDK
 
 The Operations Manager SDK has a **Matches** criteria operator for filtering objects. This operator uses the same functionality as `MatchesCriteria` in the GroupCalc case mentioned earlier.

--- a/support/system-center/scom/regular-expression-support.md
+++ b/support/system-center/scom/regular-expression-support.md
@@ -90,13 +90,13 @@ Search for any matches to folders located recursively under the two folder paths
 
 ### Example 4
 
-Search for any matches to Windows computers with display names that contain either of the two strings, `Agent1` or `Agent2`(case insensitive):
+Search for any matches that contain either of the two strings, `Agent1` or `Agent2`(case insensitive):
 
 ```perl
 ^(?i)(agent1)|(?i)(agent2)$
 ```
 
-Search for any matches to Windows computers with display names that contain `Agent` (case insensitive):
+Search for any matches that contain `Agent` (case insensitive):
 
 ```perl
 ^(?i)(agent.*)$

--- a/support/system-center/scom/regular-expression-support.md
+++ b/support/system-center/scom/regular-expression-support.md
@@ -90,13 +90,13 @@ Search for any matches to folders located recursively under the two folder paths
 
 ### Example 4
 
-Search for any matches to Windows Computers with display names that match the following (case insensitive), (`Agent1` or `Agent2`):
+Search for any matches to Windows computers with display names that contain either of the two strings, `Agent1` or `Agent2`(case insensitive):
 
 ```perl
 ^(?i)(agent1)|(?i)(agent2)$
 ```
 
-Search for any matches to Windows Computers with display names that match any name containing the following (case insensitive), (`Agent`):
+Search for any matches to Windows computers with display names that contain `Agent` (case insensitive):
 
 ```perl
 ^(?i)(agent.*)$


### PR DESCRIPTION
Assisted co-worker Joana da Rocha Carvalho (joana.carvalho@microsoft.com) with a case that required Windows Computer Display Name regular expression for multiple servers. Updated the examples to include how to write an expression for evaluating Windows Computer DisplayNames with Regular Expression.