### PR TITLE
Update w32time-event-142-time-service-stopped-advertising.md

### DIFF
--- a/support/windows-server/identity/w32time-event-142-time-service-stopped-advertising.md
+++ b/support/windows-server/identity/w32time-event-142-time-service-stopped-advertising.md
@@ -87,7 +87,7 @@ The dominant error string logged by Microsoft-Windows-Time-Service Event 142 is 
 
 4. Verify that the DC logging the 142 event can discovery a time server using `DCLocator`
 
-    >nltest /dsgetdc:\<dns domain> /timeserver /force  
+    >nltest /dsgetdc:\<dns domain> /timeserv /force  
     >nltest /dsgetdc:\<dns domain> /gtimeserv /force <- if a gtimesrv is configured in the environment
 
 5. Verify port and protocol connectivity to peer time servers


### PR DESCRIPTION
Correction to parameter sintax. Te correct sintax is "... /timeserv ..." instead of "... /timeserver ...".