### PR TITLE
XMLA DELETE Command has invalid namespace

### DIFF
--- a/support/azure/general/delete-corrupted-azure-analysis-services-database.md
+++ b/support/azure/general/delete-corrupted-azure-analysis-services-database.md
@@ -27,7 +27,7 @@ Cannot execute the Delete command: database 'Database' cannot be found
 To work around this issue, run an XML for Analysis (XMLA) query in SSMS to delete the corrupted database:
 
 ```xml
-<Delete xmlns="[https://schemas.microsoft.com/analysisservices/2003/engine](https://schemas.microsoft.com/analysisservices/2003/engine)"
+<Delete xmlns="https://schemas.microsoft.com/analysisservices/2003/engine"
     IgnoreFailures="true" >
     <Object>
         <DatabaseID>DatabaseID```</DatabaseID>


### PR DESCRIPTION
The defined XMLA DELETE command has an invalid namespace. When we run the below command, it fails: 

Existing XMLA DELETE: 

<Delete xmlns="[https://schemas.microsoft.com/analysisservices/2003/engine](https://schemas.microsoft.com/analysisservices/2003/engine)"
IgnoreFailures="true" >
    <Object>
        <DatabaseID>DatabaseID```</DatabaseID>
    </Object>
</Delete>

Fails with this error: 

Executing the query ...
The Delete element at line 8, column 27 (namespace [https://schemas.microsoft.com/analysisservices/2003/engine](https://schemas.microsoft.com/analysisservices/2003/engine)) cannot appear under Envelope/Body/Execute/Command.


Updated XMLA DELETE Command: 

<Delete xmlns="https://schemas.microsoft.com/analysisservices/2003/engine"
    IgnoreFailures="true" >
    <Object>
        <DatabaseID>DatabaseID```</DatabaseID>
    </Object>
</Delete>