### PR TITLE
Updating console command to remove typo

### DIFF
--- a/support/windows-server/networking/verify-srv-dns-records-have-been-created.md
+++ b/support/windows-server/networking/verify-srv-dns-records-have-been-created.md
@@ -63,7 +63,7 @@ To use `Nslookup` to verify the SRV records, follow these steps:
 ```console
 Server: localhost
 Address: 127.0.0.1
-_ldap._tcp.dc._msdcs. Domain_Name
+_ldap._tcp.dc._msdcs.Domain_Name
 SRV service location:
 priority= 0
 weight= 100


### PR DESCRIPTION
Forgot to make the console output mimic the removal of the same typo in step 5 in an earlier pull request; so, fixing that so they match.