### PR TITLE
Add Set-AzureADUserPassword to scenaro table

### DIFF
--- a/support/azure/active-directory/pwd-not-sync.md
+++ b/support/azure/active-directory/pwd-not-sync.md
@@ -45,5 +45,6 @@ Before troubleshooting this issue, it's important to know which scenarios allow 
 |Admins who perform password resets by using the Microsoft 365 admin center| No  |
 |Passwords at new user creation through Azure Management Portal, Microsoft 365 admin center, or Azure AD PowerShell Module| No |
 |Admins who use the Set-MsolUserPassword cmdlet by using the Azure AD PowerShell Module|No|
+|Admins who use the Set-AzureADUserPassword cmdlet by using the Azure AD V2 PowerShell Module|No|
 
 To resolve this issue, see the **Troubleshoot Password Writeback** section of [How to troubleshoot Password Management](/azure/active-directory/authentication/active-directory-passwords-troubleshoot#troubleshoot-password-writeback).


### PR DESCRIPTION
It seems that Set-AzureADUserPassword also doesn't write-back the password like Set-MsolUserPassword. It should be added to the Scenaro table. Having one and not the other listed can cause some confusion (esp since Azure AD Powershell V2 works differently). PR has this.