### PR TITLE
Update unsupported actions (PoSh)

### DIFF
--- a/support/azure/active-directory/pwd-not-sync.md
+++ b/support/azure/active-directory/pwd-not-sync.md
@@ -44,6 +44,6 @@ Before troubleshooting this issue, it's important to know which scenarios allow 
 |Admins who perform password resets by using the Azure Management Portal | Yes |
 |Admins who perform password resets by using the Microsoft 365 admin center| No  |
 |Passwords at new user creation through Azure Management Portal, Microsoft 365 admin center, or Azure AD PowerShell Module| No |
-|Admins who use the Set-MsolUserPassword cmdlet by using the Azure AD PowerShell Module|No|
+|Admins initiating password reset using PowerShell Modules V1 (MSOnline) or V2 (AzureAD)|No|
 
 To resolve this issue, see the **Troubleshoot Password Writeback** section of [How to troubleshoot Password Management](/azure/active-directory/authentication/active-directory-passwords-troubleshoot#troubleshoot-password-writeback).

--- a/support/azure/active-directory/pwd-not-sync.md
+++ b/support/azure/active-directory/pwd-not-sync.md
@@ -44,6 +44,6 @@ Before troubleshooting this issue, it's important to know which scenarios allow 
 |Admins who perform password resets by using the Azure Management Portal | Yes |
 |Admins who perform password resets by using the Microsoft 365 admin center| No  |
 |Passwords at new user creation through Azure Management Portal, Microsoft 365 admin center, or Azure AD PowerShell Module| No |
-|Admins initiating password reset using PowerShell Modules V1 (MSOnline) or V2 (AzureAD)|No|
+|Admins who perform password resets by using PowerShell Modules V1 (MSOnline) or V2 (AzureAD)|No|
 
 To resolve this issue, see the **Troubleshoot Password Writeback** section of [How to troubleshoot Password Management](/azure/active-directory/authentication/active-directory-passwords-troubleshoot#troubleshoot-password-writeback).


### PR DESCRIPTION
Following content update request https://dev.azure.com/ContentIdea/ContentIdea/_workitems/edit/159804 
Clarifying the password reset initiated from either PoSh modules (V1 or V2) is an unsupported password writeback operation