### PR TITLE
Add PowerShell for winmgmt restart

### DIFF
--- a/support/sql/tools/error-message-when-you-open-configuration-manager.md
+++ b/support/sql/tools/error-message-when-you-open-configuration-manager.md
@@ -64,7 +64,10 @@ Use the following procedure:
     > [!NOTE]
     > For this command to succeed, the *Sqlmgmproviderxpsp2up.mof* file must be present in the `%programfiles(x86)%\Microsoft SQL Server\nnn\Shared` folder.
 
-1. After you run the mofcomp tool, restart the WMI service for the changes to take effect. The service name is Windows management Instrumentation.
+1. After you run the mofcomp tool, restart the WMI service for the changes to take effect. The service name is Windows Management Instrumentation.
+    ```PowerShell
+    Get-Service winmgmt | Restart-Service -Force
+    ```
 
 ### Option 2:  Repair your SQL Server installation. For further information review Repair a Failed SQL Server Installation
 

--- a/support/sql/tools/error-message-when-you-open-configuration-manager.md
+++ b/support/sql/tools/error-message-when-you-open-configuration-manager.md
@@ -53,7 +53,7 @@ Use the following procedure:
     |Microsoft SQL Server 2005|90|
     |||
 
-1. Open an elevated  command prompt, and change the directory to the folder location from Step1.  
+1. Open an elevated command prompt, and change the directory to the folder location from Step1.  
 
 1. Then type the following command, and then press **ENTER**:
 
@@ -64,7 +64,8 @@ Use the following procedure:
     > [!NOTE]
     > For this command to succeed, the *Sqlmgmproviderxpsp2up.mof* file must be present in the `%programfiles(x86)%\Microsoft SQL Server\nnn\Shared` folder.
 
-1. After you run the mofcomp tool, restart the WMI service for the changes to take effect. The service name is Windows Management Instrumentation.
+1. After you run the mofcomp tool, restart the WMI service for the changes to take effect. To do this, open **Services** application, select **Windows Management Instrumentation**, and then select **Restart**. You can also restart the service by running the following PowerShell command as administrator:
+
     ```PowerShell
     Get-Service winmgmt | Restart-Service -Force
     ```


### PR DESCRIPTION
Add a PowerShell line for easy restarting of the Windows Management Instrumentation service. Also corrected the name capitalization to match the actual service name.