### PR TITLE
Updating incorrect OMA-URI path to disable UserESP

### DIFF
--- a/support/mem/intune/understand-troubleshoot-esp.md
+++ b/support/mem/intune/understand-troubleshoot-esp.md
@@ -233,6 +233,6 @@ ESP policy is set on a device at the time of enrollment. To disable the ESP, you
 
   Name:  Disable User ESP (choose any name that you want)  
   Description:  (enter a description)  
-  OMA-URI:  ./Vendor/MSFT/DMClient/Provider/*ProviderID*/FirstSyncStatus/SkipUserStatusPage  
+  OMA-URI:  ./Vendor/MSFT/DMClient/Provider/MS DM Server/FirstSyncStatus/SkipUserStatusPage  
   Data type:  Boolean  
   Value:  True  


### PR DESCRIPTION
our public doc has an incorrect OM-URI path to disable User Enrollment Status page, which is causing customers and Front-line engineers to be confused. we have an internal article with the correct Path https://internal.evergreen.microsoft.com/en-us/topic/4825acad-4515-b1bf-496e-c73f44665f9a 
        Name:  SkipUserStatusPage (or whatever you want)
        Description:  (whatever you want)
        OMA-URI:  ./Vendor/MSFT/DMClient/Provider/MS DM Server/FirstSyncStatus/SkipUserStatusPage
        Data type:  Boolean
        Value:  True