### PR TITLE
Fix title typo

### DIFF
--- a/support/sql/performance/resource-monitor-nonyielding-condition.md
+++ b/support/sql/performance/resource-monitor-nonyielding-condition.md
@@ -1,5 +1,5 @@
 ---
-title: Resource Monitor nony-ielding condition
+title: Resource Monitor non-yielding condition
 description: This article provides more information regarding non yielding Resource Monitor..
 ms.date: 02/12/2020
 ms.custom: sap:Performance


### PR DESCRIPTION
Typo in title caused page to read Resource Monitor "nony-ielding" condition.