### PR TITLE
Add line breaks between commands

### DIFF
--- a/support/windows-client/shell-experience/windows-search-performance-issues.md
+++ b/support/windows-client/shell-experience/windows-search-performance-issues.md
@@ -83,7 +83,17 @@ To control how the indexer treats specific file types, open **Indexing Options**
 
 ##### Defragment the index database  
 
-You can use this approach to reclaim empty space within the index database. Open an administrative Command Prompt window, and then run the following commands in the given order: **Sc config wsearch start=disable Net stop wsearch EsentUtl.exe /d %AllUsersProfile%\Microsoft\Search\Data\Applications\Windows\Windows.edb Sc config wsearch start=delayed-auto Net start wsearch**  
+You can use this approach to reclaim empty space within the index database. Open an administrative Command Prompt window, and then run the following commands in the given order: 
+
+**Sc config wsearch start=disable**
+
+**Net stop wsearch**
+
+**EsentUtl.exe /d %AllUsersProfile%\Microsoft\Search\Data\Applications\Windows\Windows.edb**
+
+**Sc config wsearch start=delayed-auto**
+
+**Net start wsearch**  
 
 For more information about how to defragment the index database, see the following Knowledge Base article:
 


### PR DESCRIPTION
The commands in the following part of the article are missing line breaks between them. I've added/I propose adding the line breaks.

"You can use this approach to reclaim empty space within the index database. Open an administrative Command Prompt window, and then run the following commands in the given order"

"Sc config wsearch start=disable Net stop wsearch EsentUtl.exe /d %AllUsersProfile%\Microsoft\Search\Data\Applications\Windows\Windows.edb Sc config wsearch start=delayed-auto Net start wsearch"

My apologies if a pull request is the incorrect method for feedback. 