### PR TITLE
Change an absolute link to a relative one

### DIFF
--- a/support/windows-client/application-management/dotnet-framework-35-installation-error.md
+++ b/support/windows-client/application-management/dotnet-framework-35-installation-error.md
@@ -23,7 +23,7 @@ _Original KB number:_ &nbsp; 2734782
 
 > [!NOTE]
 > Installation of the .NET Framework may throw errors that are not listed in this article, but you might be able to try the following steps to fix those errors as well.
-> Microsoft is releasing Out-of-band (OOB) updates for .NET Framework. [.NET Framework Out-of-band update to address issues after installing the January 11, 2022 Windows update](https://docs.microsoft.com/windows/release-health/windows-message-center#359)
+> Microsoft is releasing Out-of-band (OOB) updates for .NET Framework. [.NET Framework Out-of-band update to address issues after installing the January 11, 2022 Windows update](/windows/release-health/windows-message-center#359)
 
 ## Resolutions for Windows Server
 


### PR DESCRIPTION
Absolute link 'https://docs.microsoft.com/windows/release-health/windows-message-center#359' will be broken in isolated environments. Replace with a relative link.