### PR TITLE
Procedure 1 => i contains the wrong variable

### DIFF
--- a/support/azure/active-directory/installation-issues.md
+++ b/support/azure/active-directory/installation-issues.md
@@ -17,7 +17,7 @@ _Original KB number:_ &nbsp; 3121701
 
 1. Identify the error message. To do this, follow these steps:
 
-    1. Go to the `%localappdata%\AADConnect` folder, and then open the Synchronization Service_install.txt file.
+    1. Go to the `%ProgramData%\AADConnect` folder, and then open the Synchronization Service_install.txt file.
     2. Search for this string: **value 3**
     3. Locate the error message just before the **value 3** string in the file.
 


### PR DESCRIPTION
under procedure step 1 => the wrong variable is used: %localappdata%. This lead to an error if you try to change into the folder: %localappdata%\AADConnect what does not exists. 
The correct path is usually: C:\ProgramData\AADConnect where the variable %ProgramData%  should be used. So the correct path is: %ProgramData%\AADConnect

I'd ask to commit this minor change.