### PR TITLE
Separate commands from text

### DIFF
--- a/support/windows-server/performance/toggle-terminal-services-application-server-mode.md
+++ b/support/windows-server/performance/toggle-terminal-services-application-server-mode.md
@@ -55,16 +55,16 @@ You must put a Terminal Services server in Install mode to install or remove pro
 > [!NOTE]
 > The Install application on the Terminal Server tool is available when you install the Terminal Services role. The Install application on the Terminal Server tool switches the Terminal Server server to Execute mode when the installation is complete.
 
-You can also use the change user command to switch a Terminal Server server into Install mode. To switch a Terminal Services server into Install mode, follow these steps.
+You can also use the `change user` command to switch a Terminal Server server into Install mode. To switch a Terminal Services server into Install mode, follow these steps.
 
  > [!NOTE]
- > To determine the current mode on the Terminal Server server, run the change user /query command at a command prompt.  
+ > To determine the current mode on the Terminal Server server, run the `change user /query` command at a command prompt.  
 
 1. Click **Start**, and then click **Run**.
 
 2. In the **Open** box, type cmd, and then click **OK**.
 
-3. At the command prompt, type change user /install, and then press ENTER. The following message appears:  
+3. At the command prompt, type `change user /install`, and then press ENTER. The following message appears:  
 User session is ready to install applications.
 
 4. Type exit, and then press ENTER.
@@ -76,7 +76,7 @@ To switch a Terminal Services server into Execute mode, follow these steps:
 
 2. In the **Open** box, type cmd, and then click **OK**.
 
-3. At the command prompt, type change user /execute, and then press ENTER. The following message appears:  
+3. At the command prompt, type `change user /execute`, and then press ENTER. The following message appears:  
 User session is ready to install applications.
 
 4. Type exit, and then press ENTER.
@@ -84,6 +84,6 @@ User session is ready to install applications.
 When you install programs in Install mode, Terminal Services tracks all registry entries, and the HKEY_CURRENT_USER information is primarily written to the following registry key:  
  `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Terminal Server\Install`  
 
-When you finish the program installation, by clicking Finish or by typing change user /execute, the system returns to Execute mode. The registry information that was written to the HKEY_CURRENT_USER registry hive during installation is written to the HKEY_CURRENT_USER registry hive for each user when they log on to the Terminal Server.
+When you finish the program installation, by clicking Finish or by typing `change user /execute`, the system returns to Execute mode. The registry information that was written to the HKEY_CURRENT_USER registry hive during installation is written to the HKEY_CURRENT_USER registry hive for each user when they log on to the Terminal Server.
 
 If you installed a program before you added the Terminal Services role, the system was not "listening" to the registry writes of the installation and the registry entries were not written to the correct user registry keys. Therefore, you must reinstall the program in Install mode for the program work properly.


### PR DESCRIPTION
Make the command separate from the rest of the text, so it's obvious what is the whole string.