### PR TITLE
Convert to version agnostic

### DIFF
--- a/support/sql/install/installation-fails-if-remove-user-right.md
+++ b/support/sql/install/installation-fails-if-remove-user-right.md
@@ -1,13 +1,15 @@
 ---
 title: Installation fails when you remove user rights
-description: This article helps you resolve the problem that occurs when you install or upgrade Microsoft SQL Server after tightening security.
+description: This article helps you resolve a problem that may occur when you install or upgrade Microsoft SQL Server after tightening security.
 ms.date: 10/22/2020
 ms.custom: sap:Database Engine
 ms.prod: sql
 ---
 # SQL Server installation fails if the Setup account doesn't have certain user rights
 
-This article helps you resolve the problem that occurs when you install or upgrade Microsoft SQL Server after tightening security.
+[!INCLUDE [SQL Server No Version](../../includes/applies-to-version/_ssnoversion.md)]
+
+This article helps you resolve a problem that may occur when you install or upgrade Microsoft SQL Server after tightening security.
 
 _Original product version:_ &nbsp; SQL Server 2008, SQL Server 2008 R2, SQL Server 2012  
 _Original KB number:_ &nbsp; 2000257
@@ -16,56 +18,46 @@ _Original KB number:_ &nbsp; 2000257
 
 Consider the following scenario. To tighten security, you remove some default user rights to the local administrators group on a Windows operating system. In preparation for setting up SQL Server on this system, you add the Setup account to the local administrators group.
 
-In this scenario, if you either install or upgrade SQL Server, the installation process may fail, and you receive various error messages as noted in the following sections.
+In this scenario, if you either install or upgrade SQL Server, the installation process may fail, and you may receive various error messages similar to those noted in the following sections.
 
 - **Scenario 1:** For a new installation, the Setup program fails, and you receive the following error message:
 
     > Access is denied
+    
     Additionally, you may notice error messages that resemble the following in the Detail.txt file:
-    2009-01-02 13:00:17 SQLEngine: --SqlServerServiceSCM: Waiting for nt event 'Global\sqlserverRecComplete$NIIT' to be created
-    2009-01-02 13:00:20 SQLEngine: --SqlServerServiceSCM: Waiting for nt event 'Global\sqlserverRecComplete$NIIT' or sql process handle to be signaled
-    2009-01-02 13:00:20 Slp: Configuration action failed for feature SQL_Engine_Core_Inst during timing ConfigRC and scenario ConfigRC.
-    2009-01-02 13:00:20 Slp: Access is denied
-    2009-01-02 13:00:20 Slp: Configuration action failed for feature SQL_Engine_Core_Inst during timing ConfigRC and scenario ConfigRC.
-    2009-01-02 13:00:20 Slp: System.ComponentModel.Win32Exception: Access is denied
-    2009-01-02 13:00:20 Slp:    at System.Diagnostics.ProcessManager.OpenProcess(Int32 processId, Int32 access, Boolean throwIfExited)
-    2009-01-02 13:00:20 Slp:    at System.Diagnostics.Process.GetProcessHandle(Int32 access, Boolean throwIfExited)
-    2009-01-02 13:00:20 Slp:    at System.Diagnostics.Process.OpenProcessHandle()
-    2009-01-02 13:00:20 Slp:    at System.Diagnostics.Process.get_Handle()
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlServerServiceBase.WaitSqlServerStart(Process processSql)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlServerServiceSCM.StartSqlServer(String[] parameters)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlServerStartup.StartSQLServerForInstall(String sqlCollation, String masterFullPath, Boolean isConfiguringTemplateDBs)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlEngineDBStartConfig.ConfigSQLServerSystemDatabases(EffectiveProperties properties, Boolean isConfiguringTemplateDBs, Boolean useInstallInputs)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlEngineDBStartConfig.DoCommonDBStartConfig(ConfigActionTiming timing)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlEngineDBStartConfig.Install(ConfigActionTiming timing, Dictionary`2 actionData, PublicConfigurationBase spcb)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.PrivateConfigurationBase.Execute(ConfigActionScenario scenario, ConfigActionTiming timing, Dictionary`2 actionData, PublicConfigurationBase spcbCurrent)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.SqlFeatureConfigBase.Execute(ConfigActionScenario scenario, ConfigActionTiming timing, Dictionary`2 actionData, PublicConfigurationBase spcbCurrent)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.SlpConfigAction.ExecuteAction(String actionId)
-    2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.SlpConfigAction.Execute(String actionId, TextWriter errorStream)
-    2009-01-02 13:00:20 Slp: Exception: System.ComponentModel.Win32Exception.
-    2009-01-02 13:00:20 Slp: Source: System.
-    2009-01-02 13:00:20 Slp: Message: Access is denied.
+    
+    > 2009-01-02 13:00:17 SQLEngine: --SqlServerServiceSCM: Waiting for nt event 'Global\sqlserverRecComplete$NIIT' to be created  
+    > 2009-01-02 13:00:20 SQLEngine: --SqlServerServiceSCM: Waiting for nt event 'Global\sqlserverRecComplete$NIIT' or sql process handle to be signaled  
+    > 2009-01-02 13:00:20 Slp: Configuration action failed for feature SQL_Engine_Core_Inst during timing ConfigRC and scenario ConfigRC.  
+    > 2009-01-02 13:00:20 Slp: Access is denied  
+    > 2009-01-02 13:00:20 Slp: Configuration action failed for feature SQL_Engine_Core_Inst during timing ConfigRC and scenario ConfigRC.  
+    > 2009-01-02 13:00:20 Slp: System.ComponentModel.Win32Exception: Access is denied  
+    > 2009-01-02 13:00:20 Slp:    at System.Diagnostics.ProcessManager.OpenProcess(Int32 processId, Int32 access, Boolean throwIfExited)  
+    > 2009-01-02 13:00:20 Slp:    at System.Diagnostics.Process.GetProcessHandle(Int32 access, Boolean throwIfExited)  
+    > 2009-01-02 13:00:20 Slp:    at System.Diagnostics.Process.OpenProcessHandle()  
+    > 2009-01-02 13:00:20 Slp:    at System.Diagnostics.Process.get_Handle()  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlServerServiceBase.WaitSqlServerStart(Process processSql)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlServerServiceSCM.StartSqlServer(String[] parameters)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlServerStartup.StartSQLServerForInstall(String sqlCollation, String masterFullPath, Boolean isConfiguringTemplateDBs)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlEngineDBStartConfig.ConfigSQLServerSystemDatabases(EffectiveProperties properties, Boolean isConfiguringTemplateDBs, Boolean useInstallInputs)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlEngineDBStartConfig.DoCommonDBStartConfig(ConfigActionTiming timing)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlEngine.SqlEngineDBStartConfig.Install(ConfigActionTiming timing, Dictionary<string, string> actionData, PublicConfigurationBase spcb)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.PrivateConfigurationBase.Execute(ConfigActionScenario scenario, ConfigActionTiming timing, Dictionary<string, string> actionData, PublicConfigurationBase spcbCurrent)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.SqlFeatureConfigBase.Execute(ConfigActionScenario scenario, ConfigActionTiming timing, Dictionary<string, string> actionData, PublicConfigurationBase spcbCurrent)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.SlpConfigAction.ExecuteAction(String actionId)  
+    > 2009-01-02 13:00:20 Slp:    at Microsoft.SqlServer.Configuration.SqlConfigBase.SlpConfigAction.Execute(String actionId, TextWriter errorStream)  
+    > 2009-01-02 13:00:20 Slp: Exception: System.ComponentModel.Win32Exception.  
+    > 2009-01-02 13:00:20 Slp: Source: System.  
+    > 2009-01-02 13:00:20 Slp: Message: Access is denied.  
 
-- **Scenario 2** : Upgrades to SQL Server 2008 will report the following error message on the `Engine_SqlEngineHealthCheck` rule:
-
-    > Rule name:Engine_SqlEngineHealthCheck
-    Rule description: Checks whether the SQL Server service can be restarted; or for a clustered instance, whether the SQL Server resource is online.
-    Result: Failed
-    Message/Corrective Action: The SQL Server service cannot be restarted; or for a clustered instance, the SQL Server resource is not online
-    Additionally, you may notice error messages that resemble the following in the Detail.txt file
-    2009-05-27 17:50:20 SQLEngine: : Checking Engine checkpoint 'GetSqlServerProcessHandle_1'
-    2009-05-27 17:50:20 SQLEngine: --SqlServerServiceSCM: Waiting for nt event 'Global\sqlserverRecComplete$SQL10' to be created
-    2009-05-27 17:50:22 SQLEngine: --SqlServerServiceSCM: Waiting for nt event 'Global\sqlserverRecComplete$SQL10' or sql process handle to be signaled
-    2009-05-27 17:50:22 SQLEngine: --FacetSqlEngineHealthCheck: Engine_SqlEngineHealthCheck: Error: Access is denied
-
-- **Scenario3:** A new installation of SQL Server 2012 or SQL Server 2008 R2 fails
+- **Scenario2:** A new installation of SQL Server fails
 
     You see the following error message when you try to install a new instance of SQL Server 2012 or SQL Server 2008 R2:
 
-    > Rule "Setup account privileges" failed.
-    The account that is running SQL Server Setup does not have one or all of the following rights: the right to back up files and directories, the right to manage auditing and the security log and the right to debug programs. To continue, use an account with both of these rights.
+    > Rule "Setup account privileges" failed.  
+    > The account that is running SQL Server Setup does not have one or all of the following rights: the right to back up files and directories, the right to manage auditing and the security log and the right to debug programs. To continue, use an account with both of these rights.
 
-- **Scenario 4** : Installing SQL Server 2012 or a later instance fails when you specify a network share (UNC path) for the Backup directory location. When this issue occurs, you receive the following error message:
+- **Scenario 3** : Installing SQL Server 2012 or a later instance fails when you specify a network share (UNC path) for the Backup directory location. When this issue occurs, you receive the following error message:
 
     > SQL Server setup account does not have the SeSecurityPrivilege privilege on the specified file server in the path \<UNC backup location>. This privilege is needed in folder security setting action of SQL Server setup program. To grant this privilege, use the Local Security Policy console on this file server to add SQL Server setup account to "Manage auditing and security log" policy. This setting is available in the "User Rights Assignments" section under Local Policies in the Local Security Policy console.
 
@@ -84,13 +76,13 @@ This behavior is by design. In addition to adding the user account that's runnin
 |||
 
 > [!NOTE]
-> For more information about the permissions that are required to install SQL Server, see the "Prerequisites" section of the following MSDN articles:
+> For more information about the permissions that are required to install SQL Server, see the "Prerequisites" section of the following articles:
 
-- [How to: Install SQL Server 2008 (Setup)](/previous-versions/sql/sql-server-2008/ms143219(v=sql.100))
+- [Planning a SQL Server Installation](/sql-server/install/planning-a-sql-server-installation?view=sql-server-ver15)
 
-- [Install SQL Server 2012 from the Installation Wizard (Setup)](/previous-versions/sql/sql-server-2012/ms143219(v=sql.110))
+- [Install SQL Server from the Installation Wizard (Setup)](/sql/database-engine/install-windows/install-sql-server-from-the-installation-wizard-setup?view=sql-server-ver15)
 
-Additionally, if SMB Fileshare is used as a storage option for data directory or any other directories (User database directory, user database log directory, TempDB directory, TempDB log directory or backup directory), the following additional permissions are required for the setup account on SMB fileserver as documented in the following MSDN article:[Install SQL Server with SMB fileshare storage](/sql/database-engine/install-windows/install-sql-server-with-smb-fileshare-as-a-storage-option)
+Additionally, if SMB Fileshare is used as a storage option for data directory or any other directories (User database directory, user database log directory, TempDB directory, TempDB log directory or backup directory), the following additional permissions are required for the setup account on the SMB fileserver as documented in the following article:[Install SQL Server with SMB fileshare storage](/sql/database-engine/install-windows/install-sql-server-with-smb-fileshare-as-a-storage-option)
 
 | SMB Network share folder| FULL CONTROL| SQL Setup account |
 |---|---|---|
@@ -100,7 +92,7 @@ Additionally, if SMB Fileshare is used as a storage option for data directory or
 
 ## Resolution
 
-To add the rights to the local administrator account, follow these steps:
+To add the rights to the setup account, follow these steps:
 
 1. Log on to the computer as a user who has administrative credentials.
 2. Click **Start**, click **Run**, type *Control admintools*, and then click **OK**.
@@ -160,6 +152,6 @@ To add the rights to the local administrator account, follow these steps:
     > [!NOTE]
     > **SeSecurityPrivilege** is required in order to change the get/set ACLs from the directories and subfolders. This is the case because even users who have FULL CONTROL permissions on the directories don't have permissions to get/set OWNER and Audit information from the directory.
 
-  - Why does the error that's described in Scenario 4 occuronlyin SQL Server 2012 and later versions of SQL Server?
+  - Why does the error that's described in Scenario 3 occur only in SQL Server 2012 and later versions of SQL Server?
 
     In SQL Server 2012 and later versions, Microsoft started supporting data and log files on the SMB file share. As part of this improvement, the setup experience was further enhanced to tighten the checks so that customers don't encounter errors or issues because of insufficient permission post-installation. In pre-SQL Server 2012 versions, customers can still set up the network share path for the Backup directory when the SQL Service account doesn't have permissions to perform backup. However, they will encounter an error post-installation in this situation. These scenarios are now prevented when you start the SQL 2012 setup check on a network share.


### PR DESCRIPTION
Proposing changes to make the doc version-agnostic and the tags to show that it applies to all supported versions, removed one scenario that is only applicable for upgrading to SQL 2008 (original Scenario 2) and such upgrades are no longer supported, and fixed some formatting/grammatical issues. 

If it is not needed internally, I would also like to propose that we remove the "_Original product version:_ &nbsp; SQL Server 2008, SQL Server 2008 R2, SQL Server 2012 " line as it generates some confusion/doubts for customers.