### PR TITLE
Remove quotes in command

### DIFF
--- a/support/windows-server/deployment/cant-open-exe-files.md
+++ b/support/windows-server/deployment/cant-open-exe-files.md
@@ -39,9 +39,9 @@ Corrupt registry settings or some third-party product (or virus) can change the 
 3. Type the following command lines:
 
    ```console
-   "cd\"
+   cd\
 
-   "cd \windows"
+   cd \windows
    ```
 
    Press Enter after typing each one.


### PR DESCRIPTION
This minor change makes it easier to copy & paste the commands directly by removing the unnecessary quotes around the two commands.