### PR TITLE
Update buffer-pool-scan-runs-slowly-large-memory-machines.md

### DIFF
--- a/support/sql/performance/buffer-pool-scan-runs-slowly-large-memory-machines.md
+++ b/support/sql/performance/buffer-pool-scan-runs-slowly-large-memory-machines.md
@@ -54,7 +54,7 @@ If a scan takes more than 1 second, the XEvent will be recorded as follows when 
 
 ## Workaround
 
-There's currently no way to eliminate this problem. If an operation must finish quickly, clear the buffer pool by using the following commands before you execute it.
+There's currently no way to eliminate this problem. If an operation must finish quickly, clear the buffer pool by using the following commands before you execute it. It is likely that clearing the buffer pool is actually worse than waiting for the action to complete.
 
 1. Run `CHECKPOINT` on each database
 


### PR DESCRIPTION
The advice appears to indicate the dropCleanBuffers is actually a good thing. I cannot imagine a scenario where DropCleanBuffers is anything a DBA would actually recommend prior to performing a CheckDB.