### PR TITLE
Fix typo in Azure VM TOC

### DIFF
--- a/support/azure/virtual-machines/toc.yml
+++ b/support/azure/virtual-machines/toc.yml
@@ -226,7 +226,7 @@
       href: troubleshoot-ssh-permissions-too-open.md
   - name: Windows
     items:
-    - name: Cannot RDP becasue "You must change your password before logging on the first time" error
+    - name: Cannot RDP because "You must change your password before logging on the first time" error
       href: must-change-password.md
     - name: Cannot RDP into Azure VM because of authentication errors
       href: cannot-connect-rdp-azure-vm.md


### PR DESCRIPTION
The article "Azure virtual machine error: “You must change your password before logging on the first time”" had a typo in the TOC on the word "because":

Old text: _name: Cannot RDP becasue "You must change your password before logging on the first time" error_
New text: _name: Cannot RDP because "You must change your password before logging on the first time" error_

Addresses #520 