### PR TITLE
A suggestion regarding 230s timeout

### DIFF
--- a/support/azure/general/web-apps-performance-faqs.md
+++ b/support/azure/general/web-apps-performance-faqs.md
@@ -153,7 +153,7 @@ For more information, see [Configure web apps in App Service](/azure/app-service
 
 ## Why does my request time out after 230 seconds?
 
-Azure Load Balancer has a default idle timeout setting of four minutes. This setting is generally a reasonable response time limit for a web request. If your web app requires background processing, we recommend using Azure WebJobs. The Azure web app can call WebJobs and be notified when background processing is finished. You can choose from multiple methods for using WebJobs, including queues and triggers.
+Azure Load Balancer has a default idle timeout setting of four minutes. This setting is generally a reasonable response time limit for a web request. so, App Service returns a timeout to the client if your application does not return a response within approximately 240 seconds (230 seconds on Windows app, 240 seconds on Linux app).　If your web app requires background processing, we recommend using Azure WebJobs. The Azure web app can call WebJobs and be notified when background processing is finished. You can choose from multiple methods for using WebJobs, including queues and triggers.
 
 WebJobs is designed for background processing. You can do as much background processing as you want in a WebJob. For more information about WebJobs, see [Run background tasks with WebJobs](/azure/app-service/webjobs-create).
 


### PR DESCRIPTION
Hi team,
I suggest a modification of a sentence.
App Service 230 timeout does not happend on the Azure Load Balancer and the length of the timeout depends on the app's internal architecture for each operating systems. To prevent reader's confusion, I would like to propose some modification like this request.
Please let me know if I am wrong in any of my recognitions. 

Thanks!