### PR TITLE
Minor typo: drivers -> drives

### DIFF
--- a/support/windows-client/networking/mapped-network-drive-fail-reconnect.md
+++ b/support/windows-client/networking/mapped-network-drive-fail-reconnect.md
@@ -68,7 +68,7 @@ while($True){
 
 ### Workarounds
 
-All workarounds should be executed in standard user security context. Executing scripts in an elevated security context will prevent mapped drivers from being available in the standard user context.
+All workarounds should be executed in standard user security context. Executing scripts in an elevated security context will prevent mapped drives from being available in the standard user context.
 
 #### Workaround 1: Create a startup item
 


### PR DESCRIPTION
I found this support article through a web search and noticed a minor typo: "mapped drivers" instead of "mapped drives".