### PR TITLE
added windows 11 ansd server 2022,

### DIFF
--- a/support/windows-server/user-profiles-and-logon/manage-profile-service-slow-link-detection.md
+++ b/support/windows-server/user-profiles-and-logon/manage-profile-service-slow-link-detection.md
@@ -17,21 +17,9 @@ keywords: ProfSvc
 
 # Managing User Profile Service slow link detection
 
-**Applies to**
-
-- Windows 11
-- Windows 10
-- Windows 8.1
-- Windows 8
-- Windows Server 2022
-- Windows Server 2019
-- Windows Server 2016
-- Windows Server 2012 R2
-- Windows Server 2012
-- Windows Server 2008 R2
-- Windows Server 2008
-
 This article describes how to optimize slow link detection to effectively balance the quality of the bandwidth estimate against the amount of time spent calculating the estimate.
+
+_Applies to:_ &nbsp; Windows 11, Windows 10, Windows 8.1, Windows 8, Windows Server 2022, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008
 
 ## Summary
 

--- a/support/windows-server/user-profiles-and-logon/manage-profile-service-slow-link-detection.md
+++ b/support/windows-server/user-profiles-and-logon/manage-profile-service-slow-link-detection.md
@@ -17,9 +17,21 @@ keywords: ProfSvc
 
 # Managing User Profile Service slow link detection
 
-This article describes how to optimize slow link detection to effectively balance the quality of the bandwidth estimate against the amount of time spent calculating the estimate.
+**Applies to**
 
-_Applies to:_ &nbsp; Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008, Windows 10, Windows 8.1, Windows 8
+- Windows 11
+- Windows 10
+- Windows 8.1
+- Windows 8
+- Windows Server 2022
+- Windows Server 2019
+- Windows Server 2016
+- Windows Server 2012 R2
+- Windows Server 2012
+- Windows Server 2008 R2
+- Windows Server 2008
+
+This article describes how to optimize slow link detection to effectively balance the quality of the bandwidth estimate against the amount of time spent calculating the estimate.
 
 ## Summary
 


### PR DESCRIPTION
this is my own PR , after reading this article, I found windows 11 and server 2022, so I added windows 11, I confirmed that Windows 11 is supported for user profile service with slow link.
i arranged the windows OS edition and version in descending order.

Main article page
**https://docs.microsoft.com/troubleshoot/windows-server/user-profiles-and-logon/manage-profile-service-slow-link-detection**

![Screenshot 2022-05-17 165737](https://user-images.githubusercontent.com/3296790/168800644-06f18809-6f92-4bae-b086-d024be1c6721.jpg)
