### PR TITLE
Update services-sync-not-start.md

### DIFF
--- a/support/azure/active-directory/services-sync-not-start.md
+++ b/support/azure/active-directory/services-sync-not-start.md
@@ -17,21 +17,29 @@ _Original KB number:_ &nbsp; 2995030
 
 ## Symptoms
 
-You discover that one or more Azure AD Connect services don't start. For example, the Microsoft Azure AD Sync service (formerly known as ADSync) or the Windows Azure Active Directory Synchronization Service (formerly known as DirSync) doesn't start.
+You discover that one or more Azure AD Connect services don't start. For example, the Microsoft Azure AD Sync service (ADSync) doesn't start.
 
 ## Solution 1: Set the directory synchronization account to log on as a service in Group Policy
 
 1. Select **Start**, enter _gpedit.msc_ in the search box, and then press Enter to open the Local Group Policy Editor snap-in.
 
-2. Expand **Computer Configuration** > **Window Settings** > **Security Settings** > **Local policies**, and then select **User rights assignment**.
+2. Expand **Computer Configuration** > **Windows Settings** > **Security Settings** > **Local policies**, and then select **User rights assignment**.
 
-3. Verify that the directory synchronization service account is added to the following policies:
+3. Verify that the Azure AD Connect service account is added to the following policy settings:
 
    - Log on as a service
    - Log on as batch job
    - Log on locally
 
-4. If you made changes to the local policy, restart the computer to apply the changes.
+4. A domain group policy will take precedence over a local policy. You can check that by generating a group policy report with "```gpresult /H gpresult.htm```" from a command prompt with administrator privileges.
+
+5. Open the resulting group policy report and check if **User rights assignment** settings are applied through any domain group policy object. If yes, use **Domain Policy Management** console from a Domain Controller, to remove the following policy settings from the **Winning GPO** or update that domain group policy to include Azure AD Connect service account:
+
+   - Log on as a service
+   - Log on as batch job
+   - Log on locally
+
+6. If you made any changes to the local policy or domain group policy, restart the computer to apply the changes.
 
 ## Solution 2: Troubleshoot error messages in directory synchronization logging
 


### PR DESCRIPTION
- Update in Solution 1 to address Customer feedback at https://github.com/MicrosoftDocs/SupportArticles-docs/issues/551 :
Please note that opening the "User Rights Assignment" through gpedit.msc (Local Group Policy Editor) or secpol.msc (Local Security Policy) is the same thing so there's no need to update that part. However, "User Rights Assignment" settings can also be applied through a Domain GPO, so I've included the instructions to check that and use "Group Policy Management" console from a Domain Controller.