### PR TITLE
Update URL to version 2.0 of 21H2 ADMX Download

### DIFF
--- a/support/windows-client/group-policy/create-and-manage-central-store.md
+++ b/support/windows-client/group-policy/create-and-manage-central-store.md
@@ -22,7 +22,7 @@ _Original KB number:_ &nbsp; 3087759
 
 ## Links to download the Administrative Templates files based on the operating system version
 
-- [Administrative Templates (.admx) for Windows 10 November 2021 Update (21H2)](https://aka.ms/ADMX/Windows10-21H2)
+- [Administrative Templates (.admx) for Windows 10 November 2021 Update (21H2)](https://www.microsoft.com/en-us/download/104042)
 - [Administrative Templates (.admx) for Windows 11 October 2021 Update (21H2)](https://www.microsoft.com/download/103507)
 - [Administrative Templates (.admx) for Windows 10 May 2021 Update (21H1)](https://www.microsoft.com/download/103124)
 - [Administrative Templates (.admx) for Windows 10 October 2020 Update (20H2) - v2.0](https://www.microsoft.com/download/103060)


### PR DESCRIPTION
Current link points to version 1.0 of the 21H2 ADMX Files altouth there is already a version 2.0 released. I guess as an alternative it would also be possible to fix the forwarding in https://aka.ms/ADMX/Windows10-21H2...