### PR TITLE
AB#167159: Update troubleshoot-common-blue-screen-error.md

### DIFF
--- a/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
+++ b/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
@@ -99,7 +99,7 @@ To enable dump log and Serial Console, run the following script.
     reg unload HKLM\BROKENSYSTEM
     ```
      > [!NOTE]
-     > If the rescue VM is created manually without the `az repair` commands, you can use [sac-os-dump-enabler.ps1]((https://github.com/Azure/repair-script-library/blob/master/src/windows/sac-os-dump-enabler.ps1) to collect dump files. If the OS disk of the faulty VM is attached to the rescue VM as a data disk and online, run this script by using the **Run command** option in the rescue VM.
+     > If the rescue VM is created manually without the `az repair` commands, you can use [sac-os-dump-enabler.ps1]((https://github.com/Azure/repair-script-library/blob/master/src/windows/sac-os-dump-enabler.ps1) to collect dump files. If the OS disk of the faulty VM is attached to the rescue VM as a data disk and is online, run this script by using the **Run command** option in the rescue VM.
 
 3. [Detach the OS disk and then Re-attach the OS disk to the affected VM](./troubleshoot-recovery-disks-portal-windows.md).
 4. Start the VM to reproduce the issue, then a dump file will be generated.

--- a/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
+++ b/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
@@ -98,10 +98,9 @@ To enable dump log and Serial Console, run the following script.
 
     reg unload HKLM\BROKENSYSTEM
     ```
- > [!NOTE]
- > 
- >If the rescue VM is created manually without the `az repair` commands, you can use [sac-os-dump-enabler.ps1]((https://github.com/Azure/repair-script-library/blob/master/src/windows/sac-os-dump-enabler.ps1) to collect dump files. If the OS disk of the faulty VM is attached to the rescue VM as a data disk and online, run this script by using the **Run command** option in the rescue VM.
- >
+     > [!NOTE]
+     > If the rescue VM is created manually without the `az repair` commands, you can use [sac-os-dump-enabler.ps1]((https://github.com/Azure/repair-script-library/blob/master/src/windows/sac-os-dump-enabler.ps1) to collect dump files. If the OS disk of the faulty VM is attached to the rescue VM as a data disk and online, run this script by using the **Run command** option in the rescue VM.
+
 3. [Detach the OS disk and then Re-attach the OS disk to the affected VM](./troubleshoot-recovery-disks-portal-windows.md).
 4. Start the VM to reproduce the issue, then a dump file will be generated.
 5. Attach the OS disk to a recovery VM, collect dump file, and then [submit a support ticket](https://portal.azure.com/?#blade/Microsoft_Azure_Support/HelpAndSupportBlade) with the dump file.

--- a/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
+++ b/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
@@ -98,7 +98,10 @@ To enable dump log and Serial Console, run the following script.
 
     reg unload HKLM\BROKENSYSTEM
     ```
-
+ > [!NOTE]
+ > 
+ >If rescue VM was created manually without the "az repair" extension, you can attempt to run the script manually by copying it from github and pasting it in the "run command" option of the rescue VM ONLY if the OS disk of VM in question is properly attached as data disk AND online. win-sacdump-on: https://raw.githubusercontent.com/Azure/repair-script-library/master/src/windows/sac-os-dump-enabler.ps1 
+ >
 3. [Detach the OS disk and then Re-attach the OS disk to the affected VM](./troubleshoot-recovery-disks-portal-windows.md).
 4. Start the VM to reproduce the issue, then a dump file will be generated.
 5. Attach the OS disk to a recovery VM, collect dump file, and then [submit a support ticket](https://portal.azure.com/?#blade/Microsoft_Azure_Support/HelpAndSupportBlade) with the dump file.

--- a/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
+++ b/support/azure/virtual-machines/troubleshoot-common-blue-screen-error.md
@@ -100,7 +100,7 @@ To enable dump log and Serial Console, run the following script.
     ```
  > [!NOTE]
  > 
- >If rescue VM was created manually without the "az repair" extension, you can attempt to run the script manually by copying it from github and pasting it in the "run command" option of the rescue VM ONLY if the OS disk of VM in question is properly attached as data disk AND online. win-sacdump-on: https://raw.githubusercontent.com/Azure/repair-script-library/master/src/windows/sac-os-dump-enabler.ps1 
+ >If the rescue VM is created manually without the `az repair` commands, you can use [sac-os-dump-enabler.ps1]((https://github.com/Azure/repair-script-library/blob/master/src/windows/sac-os-dump-enabler.ps1) to collect dump files. If the OS disk of the faulty VM is attached to the rescue VM as a data disk and online, run this script by using the **Run command** option in the rescue VM.
  >
 3. [Detach the OS disk and then Re-attach the OS disk to the affected VM](./troubleshoot-recovery-disks-portal-windows.md).
 4. Start the VM to reproduce the issue, then a dump file will be generated.


### PR DESCRIPTION
If rescue VM was created manually without the "az repair" extension, you can attempt to run the script manually by copying it from github and pasting it in the "run command" option of the rescue VM ONLY if the OS disk of VM in question is properly attached as data disk AND online. win-sacdump-on: https://raw.githubusercontent.com/Azure/repair-script-library/master/src/windows/sac-os-dump-enabler.ps1 

There is another option to capture dump which is not available on public documents. This helps when customer mannualy creates repair VM without any extension.