### PR TITLE
AB#169431: Orphaned flows display blank instead on none

### DIFF
--- a/support/power-platform/power-automate/manage-orphan-flow-when-owner-leaves-org.md
+++ b/support/power-platform/power-automate/manage-orphan-flow-when-owner-leaves-org.md
@@ -24,7 +24,7 @@ Admins can maintain continuity on the business process automated by the flow by 
 > [!NOTE]
 > Only privileged users can view flows that don't have any valid owners.
 
-On the [environment page from Power Platform Admin Center](https://admin.powerplatform.microsoft.com/environments), go to **Resources** tab and then open the **Flow** list. Orphaned flows display **None** as their owner.
+On the [environment page from Power Platform Admin Center](https://admin.powerplatform.microsoft.com/environments), go to **Resources** tab and then open the **Flow** list. Orphaned flows don't have an owner displayed in the Owners column.
 
 Select **Load more** to load the next set of flows so as to ensure you've looked through all flows that might be orphaned.
 

--- a/support/power-platform/power-automate/manage-orphan-flow-when-owner-leaves-org.md
+++ b/support/power-platform/power-automate/manage-orphan-flow-when-owner-leaves-org.md
@@ -24,7 +24,7 @@ Admins can maintain continuity on the business process automated by the flow by 
 > [!NOTE]
 > Only privileged users can view flows that don't have any valid owners.
 
-On the [environment page from Power Platform Admin Center](https://admin.powerplatform.microsoft.com/environments), go to **Resources** tab and then open the **Flow** list. Orphaned flows don't have an owner displayed in the Owners column.
+On the [environment page from Power Platform Admin Center](https://admin.powerplatform.microsoft.com/environments), go to **Resources** tab and then open the **Flow** list. Orphaned flows don't have an owner displayed in the **Owners** column.
 
 Select **Load more** to load the next set of flows so as to ensure you've looked through all flows that might be orphaned.
 


### PR DESCRIPTION
Changed line 27. Looking at flows in an environment in PPAC, orphaned flows seem to have blank in the owners column instead of none. This is for both enabled and disabled flows.

![image](https://user-images.githubusercontent.com/64043240/199427146-87e2717d-ec25-4d4a-b389-98de766fe11a.png)

![image](https://user-images.githubusercontent.com/64043240/199427173-8dc5f9d1-380a-48f7-bd2c-59c7215baa2b.png)
