### PR TITLE
more powershell and some bug/typo

### DIFF
--- a/support/windows-server/identity/find-current-schema-version.md
+++ b/support/windows-server/identity/find-current-schema-version.md
@@ -88,6 +88,13 @@ Ues **DSQuery** command line:
 ```console
 dsquery * "CN=ms-Exch-Schema-Version-Pt,cn=schema,cn=configuration,dc=contoso,dc=local" -scope base -attr rangeUpper
 ```
+### Method 3
+
+Use the `Get-ItemProperty` PowerShell cmdlet. Run the following command:
+
+```powershell
+Get-ItemProperty "AD:\CN=ms-Exch-Schema-Version-Pt,cn=schema,cn=configuration,$((get-addomain).DistinguishedName)" -Name  rangeUpper
+```
 
 ### Some "rangeUpper" attribute map
 
@@ -107,7 +114,7 @@ The following information provides a mapping between the **rangeUpper** attribut
 |Exchange Server 2019 CU8, CU9|17002|
 |Exchange Server 2019 CU2, CU3, CU4, CU5, CU6, CU7|17001|
 |Exchange Server 2019 RTM, CU1|17000|
-|Exchange Server 2019 Preview|15332|
+|Exchange Server 2019 Preview|15332 ?|
 |Exchange Server 2016 CU21|15334|
 |Exchange Server 2016 CU19, CU20|1533|
 |Exchange Server 2016 CU7, CU8, CU9, CU10, CU11, CU12, CU13, CU14, CU15, CU16, CU17|15332|


### PR DESCRIPTION
|Exchange Server 2019 Preview|15332| is a dublet value with
|Exchange Server 2016 CU7, CU8, CU9, CU10, CU11, CU12, CU13, CU14, CU15, CU16, CU17|15332| 
Added Method 3 how to get automatically Exchange schema version with Powershell by using $((get-addomain).DistinguishedName) - the same princip could be used to get the value for the AD Method