### PR TITLE
Fixed typo in binary conversion

### DIFF
--- a/support/windows-client/networking/tcpip-addressing-and-subnetting.md
+++ b/support/windows-client/networking/tcpip-addressing-and-subnetting.md
@@ -39,7 +39,7 @@ An IP address is a 32-bit number. It uniquely identifies a host (computer or oth
 
 IP addresses are normally expressed in dotted-decimal format, with four numbers separated by periods, such as 192.168.123.132. To understand how subnet masks are used to distinguish between hosts, networks, and subnetworks, examine an IP address in binary notation.
 
-For example, the dotted-decimal IP address 192.168.123.132 is (in binary notation) the 32-bit number 110000000101000111101110000100. This number may be hard to make sense of, so divide it into four parts of eight binary digits.
+For example, the dotted-decimal IP address 192.168.123.132 is (in binary notation) the 32-bit number 11000000101010000111101110000100. This number may be hard to make sense of, so divide it into four parts of eight binary digits.
 
 These 8-bit sections are known as octets. The example IP address, then, becomes 11000000.10101000.01111011.10000100. This number only makes a little more sense, so for most uses, convert the binary address into dotted-decimal format (192.168.123.132). The decimal numbers separated by periods are the octets converted from binary to decimal notation.
 


### PR DESCRIPTION
Binary conversion from 192.168.123.132 corrected binary to match paragraph below.
Should be: 11000000101010000111101110000100