### PR TITLE
Update in-place-system-upgrade.md

### DIFF
--- a/support/azure/virtual-machines/in-place-system-upgrade.md
+++ b/support/azure/virtual-machines/in-place-system-upgrade.md
@@ -41,7 +41,12 @@ In-place system upgrades are supported for specific versions of Azure Windows VM
 - Windows 7 Enterprise
 - Windows Server, version 1709
 - Windows Server, version 1803
-
+- Windows Server 2012 R2 Datacenter
+-	Windows Server 2012 R2 Standard
+-	Windows Server 2012 Datacenter
+-	Windows Server 2012 Standard
+-	Windows Server 2008 R2 Datacenter
+-	Windows Server 2008 R2 Standard
 
 ## In-place system upgrade process for a Windows 10 VM
 
@@ -61,10 +66,6 @@ This process requires 45-60 minutes to complete and for the VM to restart. To do
 8. The update will download and install. User settings and data will be preserved, and the VM will restart automatically.
 
 If you have general questions about this procedure, post to [Microsoft Q&A](/answers/topics/azure-virtual-machines.html) and add the `azure-virtual-machines` tag to your question.
-
-## In-place system upgrade process for Windows Server 2016 and higher
-
-Azure supports in-place upgrade to Windows Server 2019 or Windows Server 2022.  For more information on creating upgrade media in Azure and performing an in-place upgrade, see https://review.learn.microsoft.com/en-us/azure/virtual-machines/windows-in-place-upgrade?branch=pr-en-us-222834 
 
 ## Workaround
 

--- a/support/azure/virtual-machines/in-place-system-upgrade.md
+++ b/support/azure/virtual-machines/in-place-system-upgrade.md
@@ -37,19 +37,11 @@ In-place system upgrades are supported for specific versions of Azure Windows VM
 
 ### Windows versions not yet supported for in-place system upgrades (consider using a workaround)
 
-- Windows Server 2022
-- Windows Server 2019
-- Windows Server 2016
-- Windows Server 2012 R2 Datacenter
-- Windows Server 2012 R2 Standard
-- Windows Server 2012 Datacenter
-- Windows Server 2012 Standard
-- Windows Server 2008 R2 Datacenter
-- Windows Server 2008 R2 Standard
 - Windows 8.1
 - Windows 7 Enterprise
 - Windows Server, version 1709
 - Windows Server, version 1803
+
 
 ## In-place system upgrade process for a Windows 10 VM
 
@@ -69,6 +61,10 @@ This process requires 45-60 minutes to complete and for the VM to restart. To do
 8. The update will download and install. User settings and data will be preserved, and the VM will restart automatically.
 
 If you have general questions about this procedure, post to [Microsoft Q&A](/answers/topics/azure-virtual-machines.html) and add the `azure-virtual-machines` tag to your question.
+
+## In-place system upgrade process for Windows Server 2016 and higher
+
+Azure supports in-place upgrade to Windows Server 2019 or Windows Server 2022.  For more information on creating upgrade media in Azure and performing an in-place upgrade, see https://review.learn.microsoft.com/en-us/azure/virtual-machines/windows-in-place-upgrade?branch=pr-en-us-222834 
 
 ## Workaround
 
@@ -96,10 +92,6 @@ Create an Azure VM that runs a supported version of the operating system, and th
 Follow the steps in the following article to upload the VHD to Azure and to deploy the VM.
 
 [Upload a generalized VHD and use it to create new VMs in Azure](/azure/virtual-machines/windows/upload-generalized-managed)
-
-### Method 3: Request to join Azure VM Upgrade Preview
-
-If you're interested in upgrading an operating system version that's not yet supported, you may join a Private or Public Preview program, depending on capacity and availability. Email your request to [azurevmrequest@microsoft.com](mailto:azurevmrequest@microsoft.com).
 
 ## References
 


### PR DESCRIPTION
Support for upgrades from Windows Server 2016++ are coming to Azure soon.  Making a pull request adding in the supported scenario link, removing the Server OS list and remove the email alias which should no longer be used once the article goes live.  I've put in the current working link, it will need to be revised once the content is live.  The following OS versions are still not eligible, I'm removing them from this page and asking the tech writer for the new content to add them to the new page.

- Windows Server 2012 R2 Datacenter
- Windows Server 2012 R2 Standard
- Windows Server 2012 Datacenter
- Windows Server 2012 Standard
- Windows Server 2008 R2 Datacenter
- Windows Server 2008 R2 Standard