### PR TITLE
Update support-and-installation-instructions-for-amd-epyc-9004-series…

### DIFF
--- a/support/windows-server/virtualization/support-and-installation-instructions-for-amd-epyc-9004-series-server-processors.md
+++ b/support/windows-server/virtualization/support-and-installation-instructions-for-amd-epyc-9004-series-server-processors.md
@@ -62,6 +62,4 @@ In systems running Windows Server 2019 with the Hyper-V virtualization feature e
 
 For more information, see [Windows Server 2019 Hyper-V host behavior running in the Minroot configuration](windows-server-hyper-v-host-minroot-behaviors.md).
 
-Attempting to boot to the Windows Server 2019 Recovery Environment (WinRE) may result in a blue screen error 0x5C HAL_INITIALIZATION_FAILED. The WinRE image must be updated to support configurations with greater than 64 cores per socket. To enable this support, apply the latest cumulative update for Server 2019 to the WinRE image. See the article below for instructions.
-
-- [Add an update package to Windows RE](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/add-update-to-winre?view=windows-11)
+Attempting to boot to the Windows Server 2019 Recovery Environment (WinRE) may result in a blue screen error 0x5C HAL_INITIALIZATION_FAILED. The WinRE image must be updated to support configurations with greater than 64 cores per socket. To enable this support, apply the latest cumulative update for Server 2019 to the WinRE image. See [Add an update package to Windows RE](/windows-hardware/manufacture/desktop/add-update-to-winre?view=windows-11) for instructions.

--- a/support/windows-server/virtualization/support-and-installation-instructions-for-amd-epyc-9004-series-server-processors.md
+++ b/support/windows-server/virtualization/support-and-installation-instructions-for-amd-epyc-9004-series-server-processors.md
@@ -61,3 +61,7 @@ In systems running Windows Server 2019 with the Hyper-V virtualization feature e
 * The root partition may not utilize all maximum 320 logical processors available when running Minroot configuration.
 
 For more information, see [Windows Server 2019 Hyper-V host behavior running in the Minroot configuration](windows-server-hyper-v-host-minroot-behaviors.md).
+
+Attempting to boot to the Windows Server 2019 Recovery Environment (WinRE) may result in a blue screen error 0x5C HAL_INITIALIZATION_FAILED. The WinRE image must be updated to support configurations with greater than 64 cores per socket. To enable this support, apply the latest cumulative update for Server 2019 to the WinRE image. See the article below for instructions.
+
+- [Add an update package to Windows RE](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/add-update-to-winre?view=windows-11)


### PR DESCRIPTION
…-server-processors.md

The WinRE image does not contain the Server 2019 fixes for high core count support. The system will not be able to boot into the Recovery Environment. This is a document change request that explains the problem the solution.