### PR TITLE
updating information on DirSync Override

### DIFF
--- a/support/azure/active-directory/troubleshoot-aad-connect-objects-attributes.md
+++ b/support/azure/active-directory/troubleshoot-aad-connect-objects-attributes.md
@@ -528,7 +528,7 @@ Fortunately, the issues that affect these components usually generate an error i
 
   Together with this update, Azure AD also sets a **DirSyncOverrides** on the object to flag that this user has the mobile phone number "overwritten" in Azure AD. From this point on, any update to the mobile attribute that originates from on-premises will be ignored because this attribute will no longer be managed by on-premises AD.
 
-  A support engineer can file an internal escalation request to revert the mobile SoA to on-premises by providing the **objectId** of the target users. However, this method is not recommended because this issue might occur again if a user or admin updates the **Mobile** attribute in the Office Portal or through PowerShell.
+  For further Information please have a look on the article [How to use the BypassDirSyncOverrides feature of an Azure AD tenant](/azure/active-directory/hybrid/how-to-bypassdirsyncoverrides)
 
 - **UserPrincipalName changes do not update in Azure AD**
 


### PR DESCRIPTION
removed all information, that customer should raise a support case and added the referral to our new public article about DirSync Override feature.