### PR TITLE
Update in-place-system-upgrade.md

### DIFF
--- a/support/azure/virtual-machines/in-place-system-upgrade.md
+++ b/support/azure/virtual-machines/in-place-system-upgrade.md
@@ -37,15 +37,6 @@ In-place system upgrades are supported for specific versions of Azure Windows VM
 
 ### Windows versions not yet supported for in-place system upgrades (consider using a workaround)
 
-- Windows Server 2022
-- Windows Server 2019
-- Windows Server 2016
-- Windows Server 2012 R2 Datacenter
-- Windows Server 2012 R2 Standard
-- Windows Server 2012 Datacenter
-- Windows Server 2012 Standard
-- Windows Server 2008 R2 Datacenter
-- Windows Server 2008 R2 Standard
 - Windows 8.1
 - Windows 7 Enterprise
 - Windows Server, version 1709
@@ -96,10 +87,6 @@ Create an Azure VM that runs a supported version of the operating system, and th
 Follow the steps in the following article to upload the VHD to Azure and to deploy the VM.
 
 [Upload a generalized VHD and use it to create new VMs in Azure](/azure/virtual-machines/windows/upload-generalized-managed)
-
-### Method 3: Request to join Azure VM Upgrade Preview
-
-If you're interested in upgrading an operating system version that's not yet supported, you may join a Private or Public Preview program, depending on capacity and availability. Email your request to [azurevmrequest@microsoft.com](mailto:azurevmrequest@microsoft.com).
 
 ## References
 


### PR DESCRIPTION
Removing the Windows Server content from this article as well as the special alias.  We have a new Windows Server article for in-place upgrade.  Can we add a section for customers that points to it instead: https://learn.microsoft.com/en-us/azure/virtual-machines/windows-in-place-upgrade 

We have moved the unsupported Windows Server versions into this article and are killing off the alias.  I tried to submit this internally but it wouldnt let me so ping me with any questions (joscon)