### PR TITLE
Update error-2767-query-secondary-replica-fails.md

### DIFF
--- a/support/sql/database-engine/availability-groups/error-2767-query-secondary-replica-fails.md
+++ b/support/sql/database-engine/availability-groups/error-2767-query-secondary-replica-fails.md
@@ -25,7 +25,7 @@ When offloading read-only workloads to a secondary replica of an Always On avail
 
 ## Cause
 
-This issue occurs because an active transaction prevents the log record of cache from accessing and refreshing the statistics on the secondary replica.
+This issue occurs because an active transaction prevents the cache invalidation log record from accessing and refreshing the statistics on the secondary replica.
 
 ## Workaround
 

--- a/support/sql/database-engine/availability-groups/error-2767-query-secondary-replica-fails.md
+++ b/support/sql/database-engine/availability-groups/error-2767-query-secondary-replica-fails.md
@@ -25,7 +25,7 @@ When offloading read-only workloads to a secondary replica of an Always On avail
 
 ## Cause
 
-This issue occurs because an active transaction prevents the log record of cache invalidation from accessing and refreshing the statistics on the secondary replica.
+This issue occurs because an active transaction prevents the log record of cache from accessing and refreshing the statistics on the secondary replica.
 
 ## Workaround
 


### PR DESCRIPTION
Cause
This issue occurs because an active transaction prevents the log record of cache invalidation from accessing and refreshing the statistics on the secondary replica.

 Should read

 Cause
This issue occurs because an active transaction prevents the log record of cache invalidation from accessing and refreshing the statistics on the secondary replica.