### PR TITLE
Update support-and-installation-instructions-for-amd-epyc-9004-series…

### DIFF
--- a/support/windows-server/virtualization/support-and-installation-instructions-for-amd-epyc-9004-series-server-processors.md
+++ b/support/windows-server/virtualization/support-and-installation-instructions-for-amd-epyc-9004-series-server-processors.md
@@ -33,7 +33,7 @@ When installing Windows Server operating system (OS), use the latest installatio
 To install Windows Server on systems that use AMD EPYC 96x4 SKUs that have more than 64 cores, the following OS media images are required:
 
 * Windows Server 2019: Build 17763.3532 (2022 October) or later
-* Windows Server 2022: Build 20348.405 (2021 December) or later
+* Windows Server 2022: Build 20348.405 (2022 March) or later
 
 To use earlier OS media releases prior to aforementioned releases, use one of the following options:
 


### PR DESCRIPTION
…-server-processors.md

Updated the install instructions for Server 2022 to use media from March of 2022 instead of December 2021 as the newer media includes necessary Hyper-V fixes.