### PR TITLE
Update transfer-logins-passwords-between-instances.md

### DIFF
--- a/support/sql/database-engine/security/transfer-logins-passwords-between-instances.md
+++ b/support/sql/database-engine/security/transfer-logins-passwords-between-instances.md
@@ -166,7 +166,7 @@ To transfer the logins, use one of the following methods, as appropriate for you
         
                         IF (@type IN ( 'G', 'U'))
                         BEGIN -- NT authenticated account/group 
-                          SET @tmpstr = 'CREATE LOGIN ' + QUOTENAME( @name ) + ' FROM WINDOWS WITH DEFAULT_DATABASE = [' + @defaultdb + ']'
+                          SET @tmpstr = 'CREATE LOGIN ' + QUOTENAME( @name ) + ' FROM WINDOWS WITH DEFAULT_DATABASE = [' + @defaultdb + ']' + ', DEFAULT_LANGUAGE = [' + @defaultlanguage + ']'
                         END
                         ELSE 
                         BEGIN -- SQL Server authentication


### PR DESCRIPTION
Include default language on NT authenticated accounts/groups.  It is already present for SQL Server authenticated logins.