### PR TITLE
Update common-errors-creating-and-assigning-flow-approvals.md

### DIFF
--- a/support/power-platform/power-automate/common-errors-creating-and-assigning-flow-approvals.md
+++ b/support/power-platform/power-automate/common-errors-creating-and-assigning-flow-approvals.md
@@ -1,9 +1,9 @@
 ---
 title: Common errors creating and assigning flow approvals
 description: Common Power Automate approval errors and potential resolutions.
-ms.reviewer: sranjan, hamenon
+ms.reviewer: hamenon, mansong
 ms.topic: troubleshooting
-ms.date: 3/31/2021
+ms.date: 02/07/2023
 ms.subservice: power-automate-flows
 ---
 # Common errors creating and assigning flow approvals

--- a/support/power-platform/power-automate/common-errors-creating-and-assigning-flow-approvals.md
+++ b/support/power-platform/power-automate/common-errors-creating-and-assigning-flow-approvals.md
@@ -43,7 +43,7 @@ The record identifier passed to "Wait for an approval" is null, empty, or not a 
 
 > Found multiple matching users ('\<ID>, \<ID>') for 'someUserName@contoso.com'.
 
-This error will occur if two users in Microsoft Graph were found for the same Assigned To input (email address or UPN). Rather than potentially assign the approval to the wrong user account, Flow will fail the run. The unique AAD object ids for the two or more matching records are returned in the error message so that users can investigate further with a user administrator in their tenant. (The user accounts can be viewed on `graph.microsoft.com`).
+This error will occur if two users in Microsoft Graph were found for the same Assigned To (or Requestor) input (email address or UPN). Rather than potentially assign the approval to the wrong user account, Flow will fail the run. The unique AAD object ids for the two or more matching records are returned in the error message so that users can investigate further with a user administrator in their tenant. (The user accounts can be viewed on `graph.microsoft.com`).
 
 ## Attachments
 


### PR DESCRIPTION
The GraphUserDetailByEmailMultipleFound error can also happen if the Requestor input resolves to more than one AAD object. 

Because the Requestor input is not displayed by default (you must click Show advanced options to see it), it can cause confusion since the error reported is not related to the identity of users in the Assigned To input.