### PR TITLE
Minor instruction fix

### DIFF
--- a/support/windows-server/remote/install-rds-host-role-service-without-connection-broker.md
+++ b/support/windows-server/remote/install-rds-host-role-service-without-connection-broker.md
@@ -79,7 +79,7 @@ Unless otherwise noted, these steps apply to both workgroup computer and DC case
 
 1. Change the local policy of the computer to add your remote desktop users to the **Allow logon through Remote Desktop Services** local policy object. To do this, follow these steps:
 
-    1. Open Local Security Policy.
+    1. Open Local Group Policy.
     2. Navigate to **Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment**.
     3. Double-click **Allow log on through Remote Desktop Services**, and then select **Add User or Group**.
     4. Type **Remote Desktop Users** (or the user names of each user account that you want to add, separated by semicolons), and then select **OK** two times.


### PR DESCRIPTION
For me, the path `Computer Configuration\Windows Settings\Security Settings\Local Policies\User Rights Assignment` is located under Local Group Policy. 

If you want to use Local Security Policy, the path is just `Security Settings\Local Policies\User Rights Assignment` instead.

OS: Windows Server 2019