### PR TITLE
Query for sys.dm_os_memory_clerks is referencing non-existent columns

### DIFF
--- a/support/sql/database-engine/performance/dbcc-memorystatus-monitor-memory-usage.md
+++ b/support/sql/database-engine/performance/dbcc-memorystatus-monitor-memory-usage.md
@@ -178,12 +178,10 @@ sum(virtual_memory_reserved_kb) as [VM Reserved],
 sum(virtual_memory_committed_kb) as [VM Committed],
 sum(awe_allocated_kb) as [AWE Allocated],
 sum(shared_memory_reserved_kb) as [SM Reserved],
-sum(shared_memory_committed_kb) as [SM Committed],
-sum(multi_pages_kb) as [MultiPage Allocator],
-sum(single_pages_kb) as [SinlgePage Allocator]
+sum(shared_memory_committed_kb) as [SM Committed]
 from
 sys.dm_os_memory_clerks
-group by type
+group by type;
 ```
 
 ### Buffer distribution


### PR DESCRIPTION
if you execute this query in SQL Server 2022:

select
type,
sum(virtual_memory_reserved_kb) as [VM Reserved],
sum(virtual_memory_committed_kb) as [VM Committed], sum(awe_allocated_kb) as [AWE Allocated],
sum(shared_memory_reserved_kb) as [SM Reserved],
sum(shared_memory_committed_kb) as [SM Committed], sum(multi_pages_kb) as [MultiPage Allocator],
sum(single_pages_kb) as [SinlgePage Allocator]
from
sys.dm_os_memory_clerks
group by type;

it will not work because the two columns multi_pages_kb , single_pages_kb don't exist in dmv sys.dm_os_memory_clerks

so the article query should be updated to:

select
type,
sum(virtual_memory_reserved_kb) as [VM Reserved],
sum(virtual_memory_committed_kb) as [VM Committed], sum(awe_allocated_kb) as [AWE Allocated],
sum(shared_memory_reserved_kb) as [SM Reserved],
sum(shared_memory_committed_kb) as [SM Committed]
from
sys.dm_os_memory_clerks
group by type;