### PR TITLE
Update configure-dtc-to-work-through-firewalls.md

### DIFF
--- a/support/windows-server/application-management/configure-dtc-to-work-through-firewalls.md
+++ b/support/windows-server/application-management/configure-dtc-to-work-through-firewalls.md
@@ -1,7 +1,7 @@
 ---
 title: Configure Distributed Transaction Coordinator (DTC) to work through a firewall
 description: Describes how to configure DTC to work through firewalls.
-ms.date: 9/24/2021
+ms.date: 05/06/2023
 author: Deland-Han
 ms.author: delhan
 manager: dcscontentpm
@@ -17,14 +17,14 @@ ms.technology: windows-server-application-compatibility
 
 This article describes how to configure Microsoft Distributed Transaction Coordinator (DTC) to work through firewalls.
 
-_Applies to:_ &nbsp; Windows Server 2022, 2019, 2016, 2012 R2  
+_Applies to:_ &nbsp; Windows Server 2012 R2, Windows Server 2016, Windows Server 2019, Windows Server 2022  
 _Original KB number:_ &nbsp; 250367
 
 ## More information
 
 You can configure DTC to communicate through firewalls, including network address translation firewalls.
 
-DTC uses Remote Procedure Call (RPC) dynamic port allocation. By default, RPC dynamic port allocation randomly selects port numbers in the 49152-65535 range. By modifying the registry, you can control which ports RPC dynamically allocates for incoming communication. You can then configure your firewall to confine incoming external communication to only those ports and port 135 (the RPC Endpoint Mapper port). It is recommended to use the default 135,49152-65535 range in firewalls to avoid port exhaustion and only change to fewer ports if firewalls cannot filter on computer or IPs.  
+DTC uses Remote Procedure Call (RPC) dynamic port allocation. By default, RPC dynamic port allocation randomly selects port numbers in the 49152-65535 range. By modifying the registry, you can control which ports RPC dynamically allocates for incoming communication. You can then configure your firewall to confine incoming external communication to only those ports and port 135 (the RPC Endpoint Mapper port). It is recommended to use the default 135, 49152-65535 range in firewalls to avoid port exhaustion and only change to fewer ports if firewalls cannot filter on computer or IPs.  
 
 You must provide one incoming dynamic port for DTC. It is recommend to use a fixed port for each DTC instance. You can have one local DTC instance and multiple clustered DTC instances. You may need to provide more incoming dynamic ports for other subsystems that rely on RPC so it is .
 
@@ -33,7 +33,7 @@ The registry keys and values described in this article don't appear in the regis
 > [!IMPORTANT]
 > This section, method, or task contains steps that tell you how to modify the registry. However, serious problems might occur if you modify the registry incorrectly. Therefore, make sure that you follow these steps carefully. For added protection, back up the registry before you modify it. Then, you can restore the registry if a problem occurs. For more information about how to back up and restore the registry, see [How to back up and restore the registry in Window](https://support.microsoft.com/help/322756).
 
-Follow these steps on computers involved in DTC transcations to set fixed port for DTC. The firewall must be open in both directions for the fixed port and port 135. 
+Follow these steps on computers involved in DTC transactions to set fixed port for DTC. The firewall must be open in both directions for the fixed port and port 135.
 
 1. To start Registry Editor, select **Start**, select **Run**, type *regedt32*, and then select **OK**.
 2. In Registry Editor, select **HKEY_LOCAL_MACHINE** in the **Local Machine** window.
@@ -43,14 +43,14 @@ Follow these steps on computers involved in DTC transcations to set fixed port f
 6. Right-click and choose **Modify** on the new value.
 7. In the **Value Editor** dialog box, select **Decimal** and then put your fixed port number, e g 40001, in the **Value data** field, and then select **OK**.
 
-To configure fixed port for clustered DTC instances you need to find the cluster resource GUID and add the ServerTcpPort under this location. Use different port number for each DTC instance. E g if your DTC resource guid is 012345678-9abc-def0-1234-56789abcdef0, then it would be in this path:
-`HKEY_LOCAL_MACHINE\Cluster\Resources\012345678-9abc-def0-1234-56789abcdef0\MSDTCPRIVATE\MSDTC`
-Repeat the same for additional DTC clustered resources. 
+To configure fixed port for clustered DTC instances, you need to find the cluster resource GUID and add the **ServerTcpPort** value under this location. Use different port number for each DTC instance. For example, if your DTC resource GUID is 012345678-9abc-def0-1234-56789abcdef0, then it would be in this path: `HKEY_LOCAL_MACHINE\Cluster\Resources\012345678-9abc-def0-1234-56789abcdef0\MSDTCPRIVATE\MSDTC`. Repeat the steps for additional DTC clustered resources.
 
-Alternative reg add commands which can be used in admin cmd scripts to do same as above (adjust to your specific cluster guid if clustered DTC instance is used):
+Alternative, you can use the `reg add` commands in scripts with administrator privileges to do this operation. Adjust the following example to your specific cluster GUID if clustered DTC instance is used:
+
+```console
 reg add HKLM\SOFTWARE\Microsoft\MSDTC /v ServerTcpPort /t REG_DWORD /d 40001 /f 
 reg add HKLM\Cluster\Resources\012345678-9abc-def0-1234-56789abcdef0\MSDTCPRIVATE\MSDTC /v ServerTcpPort /t REG_DWORD /d 40002 /f
-
+```
 
 Follow these steps on computers involved in DTC transactions where firewalls prevent full communication to control RPC dynamic port allocation. The firewall must be open in both directions for the specified ports and port 135:
 
@@ -70,7 +70,7 @@ Follow these steps on computers involved in DTC transactions where firewalls pre
 
    Each string value you type specifies either a single port or an inclusive range of ports. For example, to open port 40000, specify **40000** without the quotation marks. To open ports 40000 to 42000 inclusive, specify **40000-42000** without the quotation marks. You can specify multiple ports or ports ranges by specifying one port or port range per line. All ports must be in the range of 1024 to 65535. If any port is outside this range or if any string is invalid, RPC will treat the entire configuration as invalid.
 
-   Microsoft recommends that you open up ports from 20000 and up, as lower ports may often be in use by other applications, and that you open a minimum of 1000 ports to avoid port exhaustion. On high load systems you may need more ports. The default range of 1024-5000 was moved in Windows 2008 and above to 49152-65535 range to avoid port exhaustion. 
+   Microsoft recommends that you open up ports from 20000 and up, as lower ports may often be in use by other applications, and that you open a minimum of 1000 ports to avoid port exhaustion. On high load systems you may need more ports. The default range of 1024-5000 was moved in Windows 2008 and above to 49152-65535 range to avoid port exhaustion.
 
 10. Follow steps 6 through 9 to add another key for Internet, by using these values:
 

--- a/support/windows-server/application-management/configure-dtc-to-work-through-firewalls.md
+++ b/support/windows-server/application-management/configure-dtc-to-work-through-firewalls.md
@@ -9,7 +9,7 @@ audience: ITPro
 ms.topic: troubleshooting
 ms.prod: windows-server
 localization_priority: medium
-ms.reviewer: kaushika, jmeier
+ms.reviewer: kaushika, jmeier, niklase
 ms.custom: sap:dtc-startup-configuration-connectivity-and-cluster, csstroubleshoot
 ms.technology: windows-server-application-compatibility
 ---
@@ -17,23 +17,42 @@ ms.technology: windows-server-application-compatibility
 
 This article describes how to configure Microsoft Distributed Transaction Coordinator (DTC) to work through firewalls.
 
-_Applies to:_ &nbsp; Windows Server 2012 R2  
+_Applies to:_ &nbsp; Windows Server 2022, 2019, 2016, 2012 R2  
 _Original KB number:_ &nbsp; 250367
 
 ## More information
 
 You can configure DTC to communicate through firewalls, including network address translation firewalls.
 
-DTC uses Remote Procedure Call (RPC) dynamic port allocation. By default, RPC dynamic port allocation randomly selects port numbers above 1024. By modifying the registry, you can control which ports RPC dynamically allocates for incoming communication. You can then configure your firewall to confine incoming external communication to only those ports and port 135 (the RPC Endpoint Mapper port).
+DTC uses Remote Procedure Call (RPC) dynamic port allocation. By default, RPC dynamic port allocation randomly selects port numbers in the 49152-65535 range. By modifying the registry, you can control which ports RPC dynamically allocates for incoming communication. You can then configure your firewall to confine incoming external communication to only those ports and port 135 (the RPC Endpoint Mapper port). It is recommended to use the default 135,49152-65535 range in firewalls to avoid port exhaustion and only change to fewer ports if firewalls cannot filter on computer or IPs.  
 
-You must provide one incoming dynamic port for DTC. You may need to provide more incoming dynamic ports for other subsystems that rely on RPC.
+You must provide one incoming dynamic port for DTC. It is recommend to use a fixed port for each DTC instance. You can have one local DTC instance and multiple clustered DTC instances. You may need to provide more incoming dynamic ports for other subsystems that rely on RPC so it is .
 
 The registry keys and values described in this article don't appear in the registry by default; you must add them by using Registry Editor.
 
 > [!IMPORTANT]
 > This section, method, or task contains steps that tell you how to modify the registry. However, serious problems might occur if you modify the registry incorrectly. Therefore, make sure that you follow these steps carefully. For added protection, back up the registry before you modify it. Then, you can restore the registry if a problem occurs. For more information about how to back up and restore the registry, see [How to back up and restore the registry in Window](https://support.microsoft.com/help/322756).
 
-Follow these steps on both computers to control RPC dynamic port allocation. The firewall must be open in both directions for the specified ports:
+Follow these steps on computers involved in DTC transcations to set fixed port for DTC. The firewall must be open in both directions for the fixed port and port 135. 
+
+1. To start Registry Editor, select **Start**, select **Run**, type *regedt32*, and then select **OK**.
+2. In Registry Editor, select **HKEY_LOCAL_MACHINE** in the **Local Machine** window.
+3. Expand the tree by double-selecting the folders named in the `HKEY_LOCAL_MACHINE\Software\Microsoft\MSDTC` path.
+4. Select the MSDTC folder, and then select **New > DWORD (32-bit) Value** on the **Edit** menu.
+5. Change the **Name** to *ServerTcpPort*.
+6. Right-click and choose **Modify** on the new value.
+7. In the **Value Editor** dialog box, select **Decimal** and then put your fixed port number, e g 40001, in the **Value data** field, and then select **OK**.
+
+To configure fixed port for clustered DTC instances you need to find the cluster resource GUID and add the ServerTcpPort under this location. Use different port number for each DTC instance. E g if your DTC resource guid is 012345678-9abc-def0-1234-56789abcdef0, then it would be in this path:
+`HKEY_LOCAL_MACHINE\Cluster\Resources\012345678-9abc-def0-1234-56789abcdef0\MSDTCPRIVATE\MSDTC`
+Repeat the same for additional DTC clustered resources. 
+
+Alternative reg add commands which can be used in admin cmd scripts to do same as above (adjust to your specific cluster guid if clustered DTC instance is used):
+reg add HKLM\SOFTWARE\Microsoft\MSDTC /v ServerTcpPort /t REG_DWORD /d 40001 /f 
+reg add HKLM\Cluster\Resources\012345678-9abc-def0-1234-56789abcdef0\MSDTCPRIVATE\MSDTC /v ServerTcpPort /t REG_DWORD /d 40002 /f
+
+
+Follow these steps on computers involved in DTC transactions where firewalls prevent full communication to control RPC dynamic port allocation. The firewall must be open in both directions for the specified ports and port 135:
 
 1. To start Registry Editor, select **Start**, select **Run**, type *regedt32*, and then select **OK**.
 
@@ -49,9 +68,9 @@ Follow these steps on both computers to control RPC dynamic port allocation. The
 8. In the **Data Type** box, select **REG_MULTI_SZ**, and then select **OK**.
 9. In the **Multi-String Editor** dialog box, in the **Data** box, specify the port or ports you want RPC to use for dynamic port allocation, and then select **OK**.
 
-   Each string value you type specifies either a single port or an inclusive range of ports. For example, to open port 5000, specify **5000** without the quotation marks. To open ports 5000 to 5020 inclusive, specify **5000-5020** without the quotation marks. You can specify multiple ports or ports ranges by specifying one port or port range per line. All ports must be in the range of 1024 to 65535. If any port is outside this range or if any string is invalid, RPC will treat the entire configuration as invalid.
+   Each string value you type specifies either a single port or an inclusive range of ports. For example, to open port 40000, specify **40000** without the quotation marks. To open ports 40000 to 42000 inclusive, specify **40000-42000** without the quotation marks. You can specify multiple ports or ports ranges by specifying one port or port range per line. All ports must be in the range of 1024 to 65535. If any port is outside this range or if any string is invalid, RPC will treat the entire configuration as invalid.
 
-   Microsoft recommends that you open up ports from 5000 and up, and that you open a minimum of 15 to 20 ports.
+   Microsoft recommends that you open up ports from 20000 and up, as lower ports may often be in use by other applications, and that you open a minimum of 1000 ports to avoid port exhaustion. On high load systems you may need more ports. The default range of 1024-5000 was moved in Windows 2008 and above to 49152-65535 range to avoid port exhaustion. 
 
 10. Follow steps 6 through 9 to add another key for Internet, by using these values:
 
@@ -71,10 +90,10 @@ Follow these steps on both computers to control RPC dynamic port allocation. The
 
 12. Configure your firewall to allow incoming access to the specified dynamic ports and to port 135 (the RPC Endpoint Mapper port).
 
-13. Restart the computer. When RPC restarts, it will assign incoming ports dynamically, based on the registry values that you've specified. For example, to open ports 5000 through 5020 inclusive, create these named values:
+13. Restart the computer. When RPC restarts, it will assign incoming ports dynamically, based on the registry values that you've specified. For example, to open ports 40000 through 42000 inclusive, create these named values:
 
-    > Ports : REG_MULTI-SZ : 5000-5020  
+    > Ports : REG_MULTI-SZ : 40000-42000  
     PortsInternetAvailable : REG_SZ : Y  
     UseInternetPorts : REG_SZ : Y
 
-DTC also requires you can resolve computer names by way of NetBIOS or DNS. Test if NetBIOS can resolve the names by using ping and the server name. The client computer must be able to resolve the name of the server. And the server must be able to resolve the name of the client. If NetBIOS can't resolve the names, add entries to the LMHOSTS files on the computers.
+DTC also requires you can resolve computer names by way of NetBIOS or DNS. Check that NetBIOS is enabled in the NIC properties and test if NetBIOS can resolve the names by using ping and the server name. The client computer must be able to resolve the name of the server. And the server must be able to resolve the name of the client. If NetBIOS can't resolve the names, add entries to the LMHOSTS files on the computers.


### PR DESCRIPTION
Change MSDTC port recommendations to use mainly fixed port or higher larger range ports instead of lower reserved range of ports.  Windows 2008 changed ports to be in 49152-65535 range instead of 1024-5000 in earlier OS.