### PR TITLE
Update Powershell commands in windows-update-issues-troubleshooting.md

### DIFF
--- a/support/windows-client/deployment/windows-update-issues-troubleshooting.md
+++ b/support/windows-client/deployment/windows-update-issues-troubleshooting.md
@@ -196,13 +196,13 @@ Windows client devices can receive updates from various sources, including Windo
 
     ```powershell
     
-    \$MUSM = New-Object -ComObject "Microsoft.Update.ServiceManager"
+    $MUSM = New-Object -ComObject "Microsoft.Update.ServiceManager"
     ```
 
 3. Run the cmdlet:
 
     ```powershell
-    \$MUSM.Services
+    $MUSM.Services
     ```
 
 Check the output for the Name and OffersWindowsUPdates parameters, which you can interpret according to this table.


### PR DESCRIPTION
There was an extra slash in front of the commands to check the Windows update services. Removed and the cmdlets now work

# Pull request guidance

Thank you for your contribution. The content team is monitoring the pull requests. Once your pull request is ready for review, please add a comment such as "PR is ready for review".
