### PR TITLE
Update remote-desktop-ip-virtualization.md

### DIFF
--- a/support/windows-server/remote/remote-desktop-ip-virtualization.md
+++ b/support/windows-server/remote/remote-desktop-ip-virtualization.md
@@ -30,13 +30,13 @@ If you want to use IP virtualization on Windows Server 2019, please follow these
 1. Start an elevated PowerShell window, and run the following command to rename the registry key:
 
    ```powershell
-   Rename-Item HKLM:\SYSTEM\ControlSet001\Services\WinSock2\Parameters\AppId_Catalog\2C69D9F1 Backup_2C69D9F1
+   Rename-Item HKLM:\SYSTEM\CurrentControlSet\Services\WinSock2\Parameters\AppId_Catalog\2C69D9F1 Backup_2C69D9F1
    ```
 
    > [!NOTE]
    > Deleting the key has the same effects, but the rename provides a way to revert back more easily if desired. The following is the default values:
    >
-   > `HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\WinSock2\Parameters\AppId_Catalog\2C69D9F1\`
+   > `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinSock2\Parameters\AppId_Catalog\2C69D9F1\`
    > **AppFullPath**: C:\Windows\System32\svchost.exe\
    > **PermittedLspCategories**: 0x40000000
 


### PR DESCRIPTION
Updated registry path to not use ControlSet001 and use the CurrentControlSet. Direct edits of the backing control set could fail is the user is not aware of which control set is the current based on the value in the select key.

# Pull request guidance

Thank you for your contribution. The content team is monitoring the pull requests. Once your pull request is ready for review, please type "#sign-off" in a new comment or add a comment such as "PR is ready for review and merge."
