### PR TITLE
Fix folder path to Azure DevOps Server

### DIFF
--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -46,7 +46,9 @@ TFS, Azure DevOps Server:
 - TFS/Azure DevOps Server cache folder
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
-- `TFSJobAgent.exe` process that is typically located at _%ProgramFiles%\Azure DevOps Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_
+- `TFSJobAgent.exe` process that is typically located at
+-  - %ProgramFiles%\Microsoft Team Foundation Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
+   - %ProgramFiles%\Azure DevOps Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
 
 Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -11,7 +11,7 @@ ms.service: azure-devops-server
 
 This article provides information about the processes and folders that may have to be excluded from antivirus scanning on computers that are running Team Foundation Server (TFS), Azure DevOps Server or self-hosted agents of Azure DevOps Services. It also provides links to Microsoft Knowledge Base articles that discuss antivirus exclusions that may be defined on servers hosting deployments of Microsoft SQL Server and SharePoint Server that have been integrated with Azure DevOps Server.
 
-_Original product version:_ &nbsp; Microsoft Team Foundation Server, Azure DevOps Server
+_Original product version:_ &nbsp; Microsoft Team Foundation Server, Azure DevOps Server    
 _Original KB number:_ &nbsp; 2636507
 
 ## Symptoms

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -47,7 +47,7 @@ TFS, Azure DevOps Server:
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
 - `TFSJobAgent.exe` process that is typically located at
--  - %ProgramFiles%\Microsoft Team Foundation Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
+   - %ProgramFiles%\Microsoft Team Foundation Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
    - %ProgramFiles%\Azure DevOps Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
 
 Azure DevOps Server, Azure DevOps Services (self-hosted agents):

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -3,7 +3,7 @@ title: Antivirus scanning exclusions
 description: This article describes the system processes that you should consider excluding from antivirus scanning on computers that are running Team Foundation Server.
 ms.date: 02/09/2022
 ms.custom: sap:Installation, Migration, and Move
-ms.reviewer: chandrur
+ms.reviewer: vimalt, manojm
 ms.topic: article
 ms.service: azure-devops-server
 ---

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -25,8 +25,8 @@ Target files will be locked when the antivirus software is scanning. Builds may 
 
 - The following event is added to the system's Application log before the Team Foundation Server Application Pool crashes:
 
-   >TF400850: The request context was not disposed by the caller  
-    Exception Message: Cannot access a disposed object.
+   > TF400850: The request context was not disposed by the caller  
+     Exception Message: Cannot access a disposed object.
 
 ## Exclusion list
 
@@ -46,7 +46,7 @@ TFS, Azure DevOps Server:
 - TFS/Azure DevOps Server cache folder
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
-- `TFSJobAgent.exe` process that is typically located at:
+- The `TFSJobAgent.exe` process that is typically located at:
    - %ProgramFiles%\Microsoft Team Foundation Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
    - %ProgramFiles%\Azure DevOps Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
 
@@ -65,12 +65,12 @@ Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 
 For better performance of source control and other TFS/Azure DevOps Server operations, we recommend adding the Internet Information Services (IIS) worker process (w3wp.exe) to the list of antivirus exclusions. This is not a requirement for TFS/Azure DevOps Server.
 
-The w3wp.exe process is typically located at _C:\Windows\System32\inetsrv\w3wp.exe_. You can also locate this process by following these steps:
+The `w3wp.exe` process is typically located at _C:\Windows\System32\inetsrv\w3wp.exe_. You can also locate this process by following these steps:
 
 1. Make a TFS/Azure DevOps Server web request by connecting to the server using Team Explorer.
 2. On the TFS/Azure DevOps Server application tier or the TFS/Azure DevOps Server proxy machine, open **Task Manager**, and then select the **Details** tab.
-3. In the list of processes that are running, find **w3wp.exe**.
-4. Right-click **w3wp.exe**, and then select **Open file location**.
+3. In the list of processes that are running, find `w3wp.exe`.
+4. Right-click `w3wp.exe`, and then select **Open file location**.
 
 For more information about SQL Server and SharePoint Server folder exclusions, see the following articles:
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -63,7 +63,7 @@ Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 
 ## More information
 
-For better performance of source control and other TFS/Azure DevOps Server operations, we recommend adding the Internet Information Services (IIS) worker process (w3wp.exe) to the list of antivirus exclusions. This is not a requirement for TFS/Azure DevOps Server.
+For better performance of source control and other TFS/Azure DevOps Server operations, we recommend adding the Internet Information Services (IIS) worker process (_w3wp.exe_) to the list of antivirus exclusions. This is not a requirement for TFS/Azure DevOps Server.
 
 The _w3wp.exe_ process is typically located at _C:\Windows\System32\inetsrv\w3wp.exe_. You can also locate this process by following these steps:
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -31,9 +31,9 @@ Target files will be locked when the antivirus software is scanning. Builds may 
 ## Exclusion list
 
 > [!WARNING]
-> Excluding a file or process from antivirus scanning could make your device or data more vulnerable. You should evaluate the risks and use discretion when implementing exclusions, and only exclude files that you're confident are safe.
+> Excluding a file or process from antivirus scanning could make your device or data more vulnerable. You should evaluate the risks and use discretion when implementing exclusions, and only exclude files that you are confident are safe.
 
-If you encounter the issue described previously, you might have to configure your antivirus software to exclude the following processes, folders and their sub-folders from antivirus scanning.
+If you encounter the issue described previously, you might have to configure your antivirus software to exclude the following processes, folders, and their sub-folders from antivirus scanning.
 
 TFS, Azure DevOps Server:
 
@@ -46,7 +46,7 @@ TFS, Azure DevOps Server:
 - TFS/Azure DevOps Server cache folder
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
-- `TFSJobAgent.exe` process that is typically located at
+- `TFSJobAgent.exe` process that is typically located at:
    - %ProgramFiles%\Microsoft Team Foundation Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
    - %ProgramFiles%\Azure DevOps Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -9,14 +9,14 @@ ms.service: azure-devops-server
 ---
 # Antivirus exclusions for Azure DevOps
 
-This article provides information about the processes and folders that may have to be excluded from antivirus scanning on computers that are running Team Foundation Server (TFS), Azure DevOps Server or self-hosted agents of Azure DevOps Services. It also provides links to Microsoft knowledge base articles that cover antivirus exclusions that may be defined on servers that are running deployments of Microsoft SQL Server and SharePoint Server that have been integrated with Azure DevOps Server.
+This article provides information about the processes and folders that may have to be excluded from antivirus scanning on computers that are running Team Foundation Server (TFS), Azure DevOps Server or self-hosted agents of Azure DevOps Services. It also provides links to Microsoft Knowledge Base articles that discuss antivirus exclusions that may be defined on servers hosting deployments of Microsoft SQL Server and SharePoint Server that have been integrated with Azure DevOps Server.
 
 _Original product version:_ &nbsp; Microsoft Team Foundation Server, Azure DevOps Server
 _Original KB number:_ &nbsp; 2636507
 
 ## Symptoms
 
-Target files will be locked when the antivirus software is scanning. Builds may take longer time to complete and you may encounter errors if proper folders aren't added to the antivirus software's directory exclusion list. These errors may include intermittent instances where the Team Foundation Server Application Pool crashes. The following list includes errors that you might encounter when this behavior occurs:
+Target files will be locked when the antivirus software is scanning. Builds may take longer time to complete and you might encounter errors if proper folders aren't added to the antivirus software's directory exclusion list. These errors might include intermittent instances where the Team Foundation Server Application Pool crashes. The following list includes errors that you might encounter:
 
 - The following event is added to the system's Application log:
 
@@ -33,7 +33,7 @@ Target files will be locked when the antivirus software is scanning. Builds may 
 > [!WARNING]
 > Excluding a file or process from antivirus scanning could make your device or data more vulnerable. You should evaluate the risks and use discretion when implementing exclusions, and only exclude files that you're confident are safe.
 
-If you encounter the issue described above, you may have to configure your antivirus software to exclude the following processes, folders and their sub-folders from antivirus scanning.
+If you encounter the issue described previously, you might have to configure your antivirus software to exclude the following processes, folders and their sub-folders from antivirus scanning.
 
 TFS, Azure DevOps Server:
 
@@ -65,12 +65,12 @@ For better performance of source control and other TFS/Azure DevOps Server opera
 
 The w3wp.exe process is typically located at _C:\Windows\System32\inetsrv\w3wp.exe_. You can also locate this process by following these steps:
 
-1. Make a TFS/Azure DevOps Server web request such as by connecting to the server through Team Explorer.
+1. Make a TFS/Azure DevOps Server web request by connecting to the server using Team Explorer.
 2. On the TFS/Azure DevOps Server application tier or the TFS/Azure DevOps Server proxy machine, open **Task Manager**, and then select the **Details** tab.
-3. Find **w3wp.exe** in the list of items that are running.
+3. In the list of processes that are running, find **w3wp.exe**.
 4. Right-click **w3wp.exe**, and then select **Open file location**.
 
-For more information about SQL Server and SharePoint Server folder exclusions, see the following:
+For more information about SQL Server and SharePoint Server folder exclusions, see the following articles:
 
 - [Configure antivirus software to work with SQL Server](../../sql/database-engine/security/antivirus-and-sql-server.md)
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -47,14 +47,14 @@ TFS, Azure DevOps Server:
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
 - The `TFSJobAgent.exe` process that is typically located at:
-   - %ProgramFiles%\Microsoft Team Foundation Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
-   - %ProgramFiles%\Azure DevOps Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
+   - _%ProgramFiles%\Microsoft Team Foundation Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_ (for TFS)
+   - _%ProgramFiles%\Azure DevOps Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_ (for Azure DevOps Server)
 
 Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 
 - Pipeline agent folders
 - `TFSbuildServicehost.exe` process for XAML builds
-- Processes for vNext builds like `Agent.Listener.exe`, `Agent.Worker.exe` and `AgentService.exe`
+- Processes for vNext builds like _Agent.Listener.exe_, _Agent.Worker.exe_, and _AgentService.exe_
 - Self-Hosted Agent folders like _\Builds, \Symbols, \Drop, \bin, \_diag, \_work_
 - _%ProgramFiles%\Microsoft Visual Studio \<VersionNumber\>_
 - _C:\Windows\Microsoft.NET\Framework_
@@ -65,12 +65,12 @@ Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 
 For better performance of source control and other TFS/Azure DevOps Server operations, we recommend adding the Internet Information Services (IIS) worker process (w3wp.exe) to the list of antivirus exclusions. This is not a requirement for TFS/Azure DevOps Server.
 
-The `w3wp.exe` process is typically located at _C:\Windows\System32\inetsrv\w3wp.exe_. You can also locate this process by following these steps:
+The _w3wp.exe_ process is typically located at _C:\Windows\System32\inetsrv\w3wp.exe_. You can also locate this process by following these steps:
 
 1. Make a TFS/Azure DevOps Server web request by connecting to the server using Team Explorer.
 2. On the TFS/Azure DevOps Server application tier or the TFS/Azure DevOps Server proxy machine, open **Task Manager**, and then select the **Details** tab.
-3. In the list of processes that are running, find `w3wp.exe`.
-4. Right-click `w3wp.exe`, and then select **Open file location**.
+3. In the list of processes that are running, find **w3wp.exe**.
+4. Right-click **w3wp.exe**, and then select **Open file location**.
 
 For more information about SQL Server and SharePoint Server folder exclusions, see the following articles:
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -47,8 +47,8 @@ TFS, Azure DevOps Server:
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
 - The `TFSJobAgent.exe` process that is typically located at:
-   - %ProgramFiles%\Microsoft Team Foundation Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
-   - %ProgramFiles%\Azure DevOps Server <VersionNumber>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
+   - %ProgramFiles%\Microsoft Team Foundation Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for TFS)
+   - %ProgramFiles%\Azure DevOps Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe (for Azure DevOps Server)
 
 Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -46,14 +46,14 @@ TFS, Azure DevOps Server:
 - TFS/Azure DevOps Server cache folder
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
-- The `TFSJobAgent.exe` process that is typically located at:
+- The _TFSJobAgent.exe_ process that is typically located at:
    - _%ProgramFiles%\Microsoft Team Foundation Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_ (for TFS)
    - _%ProgramFiles%\Azure DevOps Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_ (for Azure DevOps Server)
 
 Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 
 - Pipeline agent folders
-- `TFSbuildServicehost.exe` process for XAML builds
+- _TFSbuildServicehost.exe_ process for XAML builds
 - Processes for vNext builds like _Agent.Listener.exe_, _Agent.Worker.exe_, and _AgentService.exe_
 - Self-Hosted Agent folders like _\Builds, \Symbols, \Drop, \bin, \_diag, \_work_
 - _%ProgramFiles%\Microsoft Visual Studio \<VersionNumber\>_

--- a/support/azure/devops/antivirus-scanning-exclusions.md
+++ b/support/azure/devops/antivirus-scanning-exclusions.md
@@ -46,7 +46,7 @@ TFS, Azure DevOps Server:
 - TFS/Azure DevOps Server cache folder
   - On the server: _C:\Users\\<ServiceAccountName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
   - On the client: _C:\Users\\<UserName\>\AppData\Local\Microsoft\Azure DevOps\\<VersionNumber\>\Cache_
-- `TFSJobAgent.exe` process that is typically located at _%ProgramFiles%\Microsoft Team Foundation Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_
+- `TFSJobAgent.exe` process that is typically located at _%ProgramFiles%\Azure DevOps Server \<VersionNumber\>\Application Tier\TFSJobAgent\TFSJobAgent.exe_
 
 Azure DevOps Server, Azure DevOps Services (self-hosted agents):
 


### PR DESCRIPTION
## Proposed change

### Before
The folder path was still pointing to `Team Foundation Server <VersionNumber>`

### After
Changed the the folder path to `Azure DevOps Server <VersionNumber>`