### PR TITLE
Update ClientIpAddress parameter name to ClientIpAddresses

### DIFF
--- a/support/windows-server/windows-security/kerberos-protocol-registry-kdc-configuration-keys.md
+++ b/support/windows-server/windows-security/kerberos-protocol-registry-kdc-configuration-keys.md
@@ -183,7 +183,7 @@ The registry entries that are listed in this section must be added to the follow
 
     This value indicates whether there are more options that must be sent as KDC options in Ticket Granting Service requests (TGS_REQ).
 
-- Entry: ClientIpAddress
+- Entry: ClientIpAddresses
 
   - Type: REG_DWORD
   - Default value: 0 (This setting is 0 because of Dynamic Host Configuration Protocol and network address translation issues.)


### PR DESCRIPTION
Hello team,

as far as I can uncover from the depths of the internet and my own studies, this parameter should be called "ClientIpAddresses".
Setting the parameter "ClientIpAddress" did not work for me on Server 2019. Setting "ClientIpAddresses" did work.