### PR TITLE
Update headline "Time stamps were lost in copying files from Windows to Linux" in files-troubleshoot-linux-smb.md

### DIFF
--- a/support/azure/azure-storage/files-troubleshoot-linux-smb.md
+++ b/support/azure/azure-storage/files-troubleshoot-linux-smb.md
@@ -2,8 +2,8 @@
 title: Troubleshoot Azure Files issues in Linux (SMB)
 description: Troubleshooting Azure Files issues in Linux. See general issues related to SMB Azure file shares when you connect from Linux clients and possible resolutions.
 ms.service: azure-file-storage
-ms.date: 06/26/2023
-ms.reviewer: kendownie
+ms.date: 09/27/2023
+ms.reviewer: kendownie, v-weizhu
 ---
 
 # Troubleshoot Azure Files issues in Linux (SMB)

--- a/support/azure/azure-storage/files-troubleshoot-linux-smb.md
+++ b/support/azure/azure-storage/files-troubleshoot-linux-smb.md
@@ -23,7 +23,7 @@ You can use [AzFileDiagnostics](https://github.com/Azure-Samples/azure-files-sam
 | Standard file shares (GPv2), GRS/GZRS | :::image type="icon" source="media/files-troubleshoot-smb-authentication/yes-icon.png" border="false"::: | :::image type="icon" source="media/files-troubleshoot-smb-authentication/no-icon.png" border="false"::: |
 | Premium file shares (FileStorage), LRS/ZRS | :::image type="icon" source="media/files-troubleshoot-smb-authentication/yes-icon.png" border="false"::: | :::image type="icon" source="media/files-troubleshoot-smb-authentication/no-icon.png" border="false"::: |
 
-## <a id="timestampslost"></a>Time stamps were lost in copying files from Windows to Linux
+## <a id="timestampslost"></a>Time stamps were lost when copying files
 
 On Linux/Unix platforms, the `cp -p` command fails if different users own file 1 and file 2.
 


### PR DESCRIPTION
Section name "Time stamps were lost in copying files from Windows to Linux" does not appear to be proper one. There is no involvement of Windows. Changing to "Time stamps were lost when copying files"

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
