### PR TITLE
Adding reference to EPA doc for new Windows Server release

### DIFF
--- a/support/windows-server/identity/ldap-session-security-settings-requirements-adv190023.md
+++ b/support/windows-server/identity/ldap-session-security-settings-requirements-adv190023.md
@@ -89,3 +89,5 @@ For more information, see the following articles:
 [Extended Protection for Authentication](https://msrc.microsoft.com/blog/2009/12/extended-protection-for-authentication/)  
 
 [Control Extended Protection for Authentication using Security Policy](/archive/blogs/askds/control-extended-protection-for-authentication-using-security-policy)
+
+[Supporting Extended Protection for Authentication (EPA) in a service](/windows/win32/secauthn/epa-support-in-service)


### PR DESCRIPTION
I'm creating this as a draft. The changes are all set, but please do not merge until after my topic in the win32 repo is published on Tuesday.

Adding a link to a new EPA doc to be published on Oct 17th: Supporting Extended Protection for Authentication (EPA) in a service. You can view [my PR](https://github.com/MicrosoftDocs/win32-pr/pull/1737) for the new doc to be added when the Windows Server bits are available.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
