### PR TITLE
Update fail-to-mount-azure-file-share.md

### DIFF
--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -415,7 +415,7 @@ cifsConfPath="/etc/modprobe.d/cifs.conf"
 echo "`date` before change ${cifsConfPath}:"
               cat ${cifsConfPath} 
               if !(( grep require_gcm_256 ${cifsConfPath} )) 
-              then
+then
 modprobe cifs
               echo 1 > /sys/module/cifs/parameters/require_gcm_256
               echo "options cifs require_gcm_256=1" > ${cifsConfPath}

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -420,7 +420,7 @@ For customers who want to use AES 256 GCM encryption only which is Maximum secur
               echo "options cifs require_gcm_256=1" > ${cifsConfPath}
               echo "`date` after changing ${cifsConfPath}:"
               cat ${cifsConfPath}
-              fi
+fi
 
 **Windows:**
 This command below specifies the encryption ciphers used by the SMB client, and the preferred Encryption type without user confirmation.

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -412,7 +412,7 @@ For customers who want to use AES 256 GCM encryption only which is Maximum secur
 
 ```bash
 cifsConfPath="/etc/modprobe.d/cifs.conf" 
-              echo "`date` before change ${cifsConfPath}:"
+echo "`date` before change ${cifsConfPath}:"
               cat ${cifsConfPath} 
               if !(( grep require_gcm_256 ${cifsConfPath} )) 
               then

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -419,7 +419,7 @@ then
 modprobe cifs
 echo 1 > /sys/module/cifs/parameters/require_gcm_256
 echo "options cifs require_gcm_256=1" > ${cifsConfPath}
-              echo "`date` after changing ${cifsConfPath}:"
+echo "`date` after changing ${cifsConfPath}:"
 cat ${cifsConfPath}
 fi
 

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -403,6 +403,35 @@ AKS versions 1.25 and later versions are based on Ubuntu 22.04, which uses the L
 
 Enable the AES-128-GCM algorithm by using the **Maximum compatibility** profile or a **Custom** profile that enables AES-128-GCM. For more information, see [Azure Files Security Settings](/azure/storage/files/files-smb-protocol?tabs=azure-portal#smb-security-settings).
 
+### Cause 5: Minimum encryption requirement for a storage account not met.
+#### Solution AES128-GCM should be enabled for all storage accounts in order to successfully mount or access a file share.
+**Note:**
+For customers who want to use AES 256 GCM encryption only which is Maximum security (SMB3.1.1) should follow the following:
+**Linux:**
+**The following script would check if the client supports AES256 GCM and enforce it only if it is supported:** 
+
+              cifsConfPath="/etc/modprobe.d/cifs.conf" 
+              echo "`date` before change ${cifsConfPath}:"
+              cat ${cifsConfPath} 
+              if !(( grep require_gcm_256 ${cifsConfPath} )) 
+              then
+              modprobe cifs
+              echo 1 > /sys/module/cifs/parameters/require_gcm_256
+              echo "options cifs require_gcm_256=1" > ${cifsConfPath}
+              echo "`date` after changing ${cifsConfPath}:"
+              cat ${cifsConfPath}
+              fi
+
+**Windows:**
+This command below specifies the encryption ciphers used by the SMB client, and the preferred Encryption type without user confirmation.
+[Set-SmbClientConfiguration (SmbShare) | Microsoft Learn](/powershell/module/smbshare/set-smbclientconfiguration)
+
+Set-SmbClientConfiguration -EncryptionCiphers "AES_256_GCM" -Confirm:$false
+
+**Note that this is not available on all clients, my Windows 10 machine does not have it even though it is fully patched
+The EncryptionCiphers parameter is available beginning with 2022-06 Cumulative Update for Microsoft server operating system version 21H2 for x64-based Systems (KB5014665), and Cumulative Update for Windows 11, version 22H2 (KB5014668)**
+
+
 ## More information
 
 If you experience some other mount errors, see [Troubleshoot Azure Files problems in Linux](/azure/storage/files/storage-troubleshoot-linux-file-connection-problems).

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -417,7 +417,7 @@ echo "`date` before change ${cifsConfPath}:"
               if !(( grep require_gcm_256 ${cifsConfPath} )) 
 then
 modprobe cifs
-              echo 1 > /sys/module/cifs/parameters/require_gcm_256
+echo 1 > /sys/module/cifs/parameters/require_gcm_256
               echo "options cifs require_gcm_256=1" > ${cifsConfPath}
               echo "`date` after changing ${cifsConfPath}:"
 cat ${cifsConfPath}

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -410,7 +410,8 @@ For customers who want to use AES 256 GCM encryption only which is Maximum secur
 **Linux:**
 **The following script would check if the client supports AES256 GCM and enforce it only if it is supported:** 
 
-              cifsConfPath="/etc/modprobe.d/cifs.conf" 
+```bash
+cifsConfPath="/etc/modprobe.d/cifs.conf" 
               echo "`date` before change ${cifsConfPath}:"
               cat ${cifsConfPath} 
               if !(( grep require_gcm_256 ${cifsConfPath} )) 

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -418,7 +418,7 @@ echo "`date` before change ${cifsConfPath}:"
 then
 modprobe cifs
 echo 1 > /sys/module/cifs/parameters/require_gcm_256
-              echo "options cifs require_gcm_256=1" > ${cifsConfPath}
+echo "options cifs require_gcm_256=1" > ${cifsConfPath}
               echo "`date` after changing ${cifsConfPath}:"
 cat ${cifsConfPath}
 fi

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -416,7 +416,7 @@ echo "`date` before change ${cifsConfPath}:"
               cat ${cifsConfPath} 
               if !(( grep require_gcm_256 ${cifsConfPath} )) 
               then
-              modprobe cifs
+modprobe cifs
               echo 1 > /sys/module/cifs/parameters/require_gcm_256
               echo "options cifs require_gcm_256=1" > ${cifsConfPath}
               echo "`date` after changing ${cifsConfPath}:"

--- a/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
+++ b/support/azure/azure-kubernetes/fail-to-mount-azure-file-share.md
@@ -419,7 +419,7 @@ For customers who want to use AES 256 GCM encryption only which is Maximum secur
               echo 1 > /sys/module/cifs/parameters/require_gcm_256
               echo "options cifs require_gcm_256=1" > ${cifsConfPath}
               echo "`date` after changing ${cifsConfPath}:"
-              cat ${cifsConfPath}
+cat ${cifsConfPath}
 fi
 
 **Windows:**


### PR DESCRIPTION
Added Cause 5 :
 The below is documentation improvement bug to avoid support cases and CRIs 
Bug 25433172: unable to mount share with custom security settings(Disabled AES128 GCM)

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
