### PR TITLE
Add ICMP/SMB Ports for Cluster service Add Node Wizard

### DIFF
--- a/support/windows-server/networking/service-overview-and-network-port-requirements.md
+++ b/support/windows-server/networking/service-overview-and-network-port-requirements.md
@@ -184,6 +184,7 @@ System service name: **ClusSvc**
 |---|---|---|
 |Cluster Service|UDP and DTLS¹|3343|
 |Cluster Service|TCP|3343 (This port is required during a node join operation.)|
+|Cluster Service|ICMP|ECHO (This port is required during a node join operation from Add Node Wizard.)|
 |RPC|TCP|135|
 |Cluster Administrator|UDP|137|
 |Randomly allocated high ports²|TCP|Random port number between 49152 and 65535|

--- a/support/windows-server/networking/service-overview-and-network-port-requirements.md
+++ b/support/windows-server/networking/service-overview-and-network-port-requirements.md
@@ -185,6 +185,7 @@ System service name: **ClusSvc**
 |Cluster Service|UDP and DTLS¹|3343|
 |Cluster Service|TCP|3343 (This port is required during a node join operation.)|
 |Cluster Service|ICMP|ECHO (This port is required during a node join operation from Add Node Wizard.)|
+|Cluster Service|TCP|445 (This port is required during a node join operation from Add Node Wizard.)|
 |RPC|TCP|135|
 |Cluster Administrator|UDP|137|
 |Randomly allocated high ports²|TCP|Random port number between 49152 and 65535|


### PR DESCRIPTION
While attempting to add a node to an existing cluster, where the node was on an external network requiring explicitly ports to be opened, it was discovered that ICMP Echo was necessary for the Add Node Wizard to function.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
