### PR TITLE
Remove the confusing statement in the FPS limitation

### DIFF
--- a/support/windows-server/remote/frame-rate-limited-to-30-fps.md
+++ b/support/windows-server/remote/frame-rate-limited-to-30-fps.md
@@ -34,7 +34,7 @@ To work around the issue, create a `DWMFRAMEINTERVAL` entry in registry subkey `
 6. Select **Decimal**, type *15* in the **Value data** box, and then select **OK**. This sets the maximum frame rate to 60 frames per second (FPS).
 
     > [!NOTE]
-    > This registry entry sets the maximum frame rate limit that the remote display protocol can deliver to the remote session client. This setting does not set the actual frame rate for the remote session client. The actual frame rate in the remote session depends on other factors such as application and computer hardware resources. Additionally, not all remote display protocols support a frame rate that is greater than 30 FPS. For example, Remote Desktop Protocol (RDP) limits the frame rate to 30 FPS. Please contact the remote display protocol providers for more information.
+    > This registry entry sets the maximum frame rate limit that the remote display protocol can deliver to the remote session client. This setting does not set the actual frame rate for the remote session client. The actual frame rate in the remote session depends on other factors such as application and computer hardware resources. Additionally, not all remote display protocols support a frame rate that is greater than 30 FPS. Please contact the remote display protocol providers for more information.
 7. Exit Registry Editor, and then restart the computer.
 
 ## Frame rate mapping

--- a/support/windows-server/remote/frame-rate-limited-to-30-fps.md
+++ b/support/windows-server/remote/frame-rate-limited-to-30-fps.md
@@ -34,7 +34,7 @@ To work around the issue, create a `DWMFRAMEINTERVAL` entry in registry subkey `
 6. Select **Decimal**, type *15* in the **Value data** box, and then select **OK**. This sets the maximum frame rate to 60 frames per second (FPS).
 
     > [!NOTE]
-    > This registry entry sets the maximum frame rate limit that the remote display protocol can deliver to the remote session client. This setting does not set the actual frame rate for the remote session client. The actual frame rate in the remote session depends on other factors such as application and computer hardware resources. Additionally, not all remote display protocols support a frame rate that is greater than 30 FPS. Please contact the remote display protocol providers for more information.
+    > This registry entry sets the maximum frame rate limit that the remote display protocol can deliver to the remote session client. This setting does not set the actual frame rate for the remote session client. The actual frame rate in the remote session depends on other factors such as application and computer hardware resources. Please contact the remote display protocol providers for more information.
 7. Exit Registry Editor, and then restart the computer.
 
 ## Frame rate mapping


### PR DESCRIPTION
Remove the example in the note section as this statement is conflicting and confusing as the endpoint is able to receive and process more than 30 FPS, but it always depends on the endpoint hardware.

To avoid confusion it is better to remove the example.