### PR TITLE
Transfer order shipment confirmation failure with error message "Dimension Location cannot be left blank if dimension Batch/Serial number is set"

### DIFF
--- a/support/dynamics-365/supply-chain/warehousing/transfer-order-shipment-confirmation-failure-due-to-empty-default-receipt-location-in-transit-warehose
+++ b/support/dynamics-365/supply-chain/warehousing/transfer-order-shipment-confirmation-failure-due-to-empty-default-receipt-location-in-transit-warehose
@@ -1,0 +1,42 @@
+---
+title: Transfer order shipment confirmation failure with error message "Dimension Location cannot be left blank if dimension Batch/Serial number is set"
+description: Provides a resolution to the error that states "Dimension Location cannot be left blank if dimension Serial number is set".
+author: Mirzaab
+ms.date: 12/05/2023
+ms.topic: troubleshooting
+ms.search.form: WHSShipmentDetails_WHSShipConfirm,WHSShipPlanningListPage_WHSShipConfirm
+audience: Application User
+ms.reviewer: kamaybac
+ms.search.region: Global
+ms.author: ssasi
+ms.search.validFrom: 2023-12-05
+ms.dyn365.ops.version: 10.0.39
+---
+# Transfer order shipment for load could not be confirmed - Dimension Location cannot be left blank if dimension Batch/Serial number is set
+
+Error code: WAX2543, WAX439, SYS18738, SYS25904
+
+## Symptoms
+
+When you try to confirm a Transfer order shipment, the system shows the following error message
+
+> The shipment for load %1 could not be confirmed.
+> Dimension %1 cannot be left blank if dimension %2 is set.
+> Update has been canceled.
+
+Therefore, you can't confirm the shipment for the load.
+
+## Cause
+
+This can happen if the Transit warehouse does not have a Default receipt location.
+
+## Resolution
+
+To configure the Default receipt location for a Transit warehouse, follow these steps.
+
+1. Go to **Warehouse management** > **Setup** > **Warehouse** > **Warehouses**.
+1. Select the Transit warehouse.
+1. Select **OK**.
+1. Select **Yes** to confirm that you want to cancel the work.
+
+For more information, see [Cancel warehouse work for exception handling](/dynamics365/supply-chain/warehousing/cancel-warehouse-work).


### PR DESCRIPTION
…ult-receipt-location-in-transit-warehouse

Provides a resolution to the error that states "Dimension Location cannot be left blank if dimension Serial number is set".

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
