### PR TITLE
update windows server version / clarify point on license cost

### DIFF
--- a/support/azure/virtual-machines/server-software-support.md
+++ b/support/azure/virtual-machines/server-software-support.md
@@ -108,7 +108,7 @@ Team Foundation Server 2012 and later versions are supported.
 
 ## Windows Server
 
-Standard editions of Windows Server 2016 and Windows Server 2019 aren't available in Azure Marketplace. To use them, [upload an image](/azure/virtual-machines/windows/prepare-for-upload-vhd-image).
+Standard editions of Windows Server 2016, Windows Server 2019, and Windows Server 2022 aren't available in Azure Marketplace. To use them, [upload an image](/azure/virtual-machines/windows/prepare-for-upload-vhd-image).  Note: With the exception of [Hybrid Benefit](https://learn.microsoft.com/windows-server/get-started/azure-hybrid-benefit) scenarios, the license cost for any Windows VM is the same, so the only reason to opt for Standard Edition over Datacenter Edition would be compatibility requirements.
 
 Windows Server 2003 and later versions are supported for deployment in Microsoft Azure. Click [here](https://support.microsoft.com/help/3206074) to see more information about running Windows Server 2003 on Azure.
 

--- a/support/azure/virtual-machines/server-software-support.md
+++ b/support/azure/virtual-machines/server-software-support.md
@@ -1,8 +1,8 @@
 ---
 title: Microsoft server software support for Microsoft Azure Virtual Machines
 description: Discusses the support policy for Microsoft server software in a Microsoft Azure Virtual Machine environment.
-ms.date: 04/03/2023
-ms.reviewer: drewm, coreysa
+ms.date: 04/22/2024
+ms.reviewer: drewm, coreysa, v-weizhu
 ms.service: virtual-machines
 ms.subservice: vm-support-statements
 ms.collection: windows
@@ -108,7 +108,10 @@ Team Foundation Server 2012 and later versions are supported.
 
 ## Windows Server
 
-Standard editions of Windows Server 2016, Windows Server 2019, and Windows Server 2022 aren't available in Azure Marketplace. To use them, [upload an image](/azure/virtual-machines/windows/prepare-for-upload-vhd-image).  Note: With the exception of [Hybrid Benefit](https://learn.microsoft.com/windows-server/get-started/azure-hybrid-benefit) scenarios, the license cost for any Windows VM is the same, so the only reason to opt for Standard Edition over Datacenter Edition would be compatibility requirements.
+Standard editions of Windows Server 2016, Windows Server 2019, and Windows Server 2022 aren't available in Azure Marketplace. To use them, [upload an image](/azure/virtual-machines/windows/prepare-for-upload-vhd-image).
+
+> [!NOTE]
+> Except for [Hybrid Benefit](/windows-server/get-started/azure-hybrid-benefit) scenarios, the license cost for any Windows VM is identical. Therefore, the only reason to opt for the Standard Edition over the Datacenter Edition would be compatibility requirements.
 
 Windows Server 2003 and later versions are supported for deployment in Microsoft Azure. Click [here](https://support.microsoft.com/help/3206074) to see more information about running Windows Server 2003 on Azure.
 


### PR DESCRIPTION
**#sign-off**

- Updated info on the version of Windows Server available to include 2022.
- Added point to clarify license cost around editions (as for most people the main reason to choose standard over datacenter edition would be financial / but that seems to not be the case ([per this info](https://serverfault.com/a/1149690/137255) - so far I've not found any official MS source to clarify that).