### PR TITLE
Add argument to bcdedit command

### DIFF
--- a/support/azure/virtual-machines/error-code-0xc000000e.md
+++ b/support/azure/virtual-machines/error-code-0xc000000e.md
@@ -51,7 +51,7 @@ The Boot partition contains a folder named "Boot." This folder is hidden by defa
 1. Run the following command line as an administrator, and then record the identifier of Windows Boot Loader (not Windows Boot Manager). The identifier is a 32-character code and it looks like this: xxxxxxxx-xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx. You will use this identifier in the next step.
 
     ```console
-    bcdedit /store <Boot partition>:\boot\bcd /enum
+    bcdedit /store <Boot partition>:\boot\bcd /enum /v
     ```
 
 2. Repair the Boot Configuration data by running the following command lines. You must replace these placeholders by the actual values:


### PR DESCRIPTION
The current article says to run `bcdedit /store <Boot partition>:\boot\bcd /enum` and record the identifier. However, when running that command, the identifier attribute is not correct:

![image](https://github.com/MicrosoftDocs/SupportArticles-docs/assets/11546229/eb0daa4b-2f1c-49be-ae6a-8c96557dca14)

Adding a /v to the command `bcdedit /store <Boot partition>:\boot\bcd /enum /v` changes the identifier to the correct GUID as needed by the support article

![image](https://github.com/MicrosoftDocs/SupportArticles-docs/assets/11546229/f29065b7-4cac-4b2b-adf6-02db34ad5771)
