### PR TITLE
Fixes typo in PowerShell command, and makes formatting consistent for a few other PowerShell commands

### DIFF
--- a/support/windows-client/installing-updates-features-roles/sysprep-fails-remove-or-update-store-apps.md
+++ b/support/windows-client/installing-updates-features-roles/sysprep-fails-remove-or-update-store-apps.md
@@ -89,22 +89,33 @@ To resolve this issue, remove the package for the user who's running sysprep, an
 > [!NOTE]
 > To prevent Microsoft Store from updating apps, unplug the Internet connection or disable Automatic Updates in Audit mode before you create the image.
 
-Run the following PowerShell cmdlets:
-1. `Import-Module Appx`
-2. `Import-Module Dism`
-3. `Get-AppxPackage -AllUsers | Where PublisherId -eq 8wekyb3d8bbwe | Format-List -Property PackageFullName,PackageUserInformation`.
+1. Run the following PowerShell cmdlets:
 
-    > [!NOTE]  
-    >
-    > - In the output of this last cmdlet, check the users for whom the package is showing up as Installed. Delete these user accounts from the reference computer, or log on to the computer by using these user accounts. Then, run the cmdlet in step 4 to remove the `Appx` package.
-    > - This command lists all packages that were published by Microsoft and installed by any user of that reference computer. Because the computer is to be sysprepped, we assume that these user profiles no longer require the package.
-    > - If you have manually provisioned apps that belong to other publishers, run the following command to list them:  
-    > `Get-AppxPackage -AllUsers | Format-List -Property PackageFullName,PackageUserInformation`
+    ```powershell
+    Import-Module Appx
+    Import-Module Dism
+    Get-AppxPackage -AllUsers | Where PublisherId -eq 8wekyb3d8bbwe | Format-List -Property PackageFullName,PackageUserInformation
+    ```
 
-4. Run `Remove-AppxPackage -Package <packagefullname>`.
-5. Remove the provisioning by running the following cmdlet:
+  > [!NOTE]  
+  >
+  > - In the output of this last cmdlet, check the users for whom the package is showing up as Installed. Delete these user accounts from the reference computer, or log on to the computer by using these user accounts. Then, run the cmdlet in step 2 to remove the `Appx` package.
+  > - This command lists all packages that were published by Microsoft and installed by any user of that reference computer. Because the computer is to be sysprepped, we assume that these user profiles no longer require the package.
+  > - If you have manually provisioned apps that belong to other publishers, run the following command to list them:  
+  > 
+  > `Get-AppxPackage -AllUsers | Format-List -Property PackageFullName,PackageUserInformation`
 
-    `Remove-AppxProvisionedPackage -Online -PackageName <packagefullname>`
+2. Remove `Appx` package by running the following cmdlet:
+
+    ```powershell
+    Remove-AppxPackage -Package <packagefullname>
+    ```
+
+3. Remove the provisioning by running the following cmdlet:
+
+    ```powershell
+    Remove-AppxProvisionedPackage -Online -PackageName <packagefullname>
+    ```
 
 If you try to recover from an update issue, you can reprovision the app after you follow these steps.
 

--- a/support/windows-client/installing-updates-features-roles/sysprep-fails-remove-or-update-store-apps.md
+++ b/support/windows-client/installing-updates-features-roles/sysprep-fails-remove-or-update-store-apps.md
@@ -89,21 +89,22 @@ To resolve this issue, remove the package for the user who's running sysprep, an
 > [!NOTE]
 > To prevent Microsoft Store from updating apps, unplug the Internet connection or disable Automatic Updates in Audit mode before you create the image.
 
-1. Run the Import-Module Appx PowerShell cmdlet.
-2. Run Import-Module Dism.
-3. Run `Get-AppxPackage -AllUsers | Where PublisherId -eq 8wekyb3d8bbwe | Format-List -Property PackageFullName,PackageUserInformation`.
+Run the following PowerShell cmdlets:
+1. `Import-Module Appx`
+2. `Import-Module Dism`
+3. `Get-AppxPackage -AllUsers | Where PublisherId -eq 8wekyb3d8bbwe | Format-List -Property PackageFullName,PackageUserInformation`.
 
     > [!NOTE]  
     >
     > - In the output of this last cmdlet, check the users for whom the package is showing up as Installed. Delete these user accounts from the reference computer, or log on to the computer by using these user accounts. Then, run the cmdlet in step 4 to remove the `Appx` package.
     > - This command lists all packages that were published by Microsoft and installed by any user of that reference computer. Because the computer is to be sysprepped, we assume that these user profiles no longer require the package.
     > - If you have manually provisioned apps that belong to other publishers, run the following command to list them:  
-    > Get-AppxPackage -AllUsers | Format-List -Property PackageFullName,PackageUserInformation
+    > `Get-AppxPackage -AllUsers | Format-List -Property PackageFullName,PackageUserInformation`
 
-4. Run `Remove-AppxPackage -Package \<packagefullname>`.
+4. Run `Remove-AppxPackage -Package <packagefullname>`.
 5. Remove the provisioning by running the following cmdlet:
 
-    Remove-AppxProvisionedPackage -Online -PackageName \<packagefullname>
+    `Remove-AppxProvisionedPackage -Online -PackageName <packagefullname>`
 
 If you try to recover from an update issue, you can reprovision the app after you follow these steps.
 


### PR DESCRIPTION
Fixes extra backslash (`\`) before `<` in:

 "Run `Remove-AppxPackage -Package \<packagefullname>`."

Makes PowerShell cmdlet formatting consistent.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
