### PR TITLE
Update pxe-clients-not-start-dhcp-60-66-67-option.md

### DIFF
--- a/support/windows-server/networking/pxe-clients-not-start-dhcp-60-66-67-option.md
+++ b/support/windows-server/networking/pxe-clients-not-start-dhcp-60-66-67-option.md
@@ -13,7 +13,7 @@ ms.custom: sap:Network Connectivity and File Sharing\Dynamic Host Configuration 
 
 This article helps fix an issue where Pre-Boot Execution Environment (PXE) clients computers don't start when you configure the Dynamic Host Configuration Protocol server to use options 60, 66, 67.
 
-_Applies to:_ &nbsp; Windows Server 2012 R2  
+_Applies to:_ &nbsp; All Windows Server Versions
 _Original KB number:_ &nbsp; 259670
 
 ## Symptoms

--- a/support/windows-server/networking/pxe-clients-not-start-dhcp-60-66-67-option.md
+++ b/support/windows-server/networking/pxe-clients-not-start-dhcp-60-66-67-option.md
@@ -13,7 +13,7 @@ ms.custom: sap:Network Connectivity and File Sharing\Dynamic Host Configuration 
 
 This article helps fix an issue where Pre-Boot Execution Environment (PXE) clients computers don't start when you configure the Dynamic Host Configuration Protocol server to use options 60, 66, 67.
 
-_Applies to:_ &nbsp; All Windows Server Versions
+_Applies to:_ &nbsp; All supported versions of Windows Server
 _Original KB number:_ &nbsp; 259670
 
 ## Symptoms


### PR DESCRIPTION
setting up dhcp options 60, 66 & 67 is not supported on all server versions. so it would be appropriate to update them accordingly.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
