### PR TITLE
Update redeploy-to-new-node-windows.md

### DIFF
--- a/support/azure/virtual-machines/windows/redeploy-to-new-node-windows.md
+++ b/support/azure/virtual-machines/windows/redeploy-to-new-node-windows.md
@@ -24,7 +24,8 @@ If you have been facing difficulties troubleshooting Remote Desktop (RDP) connec
 If the VM is stuck in a failed state, try [reapplying your VM's state](vm-stuck-in-failed-state.md) before redeploying.
 
 > [!Warning]
-> After you redeploy a VM, all the data that you saved on the temporary disk and Ephemeral disk is lost. The dynamic IP addresses associated with virtual network interface are updated.
+> After you redeploy a VM, the original VM, including all the data that you saved on the temporary disk (such as drive D) and Ephemeral disk are deleted. However, the data stored on drive C and attached disks remains persisted. The configurations and associated resources are transferred to a new VM of the same size on a new host. The dynamic IP addresses associated with virtual network interface are updated.
+> 
 
 ## Use the Azure CLI
 


### PR DESCRIPTION
I've added more information so readers know what will happen after redeployment, and that they know which disk is temporary and which one remains persistent.

"After you redeploy a VM, the original VM, including all the data that you saved on the temporary disk (such as drive D) and Ephemeral disk are deleted. However, the data stored on drive C and attached disks remains persisted. The configurations and associated resources are transferred to a new VM of the same size on a new host. The dynamic IP addresses associated with virtual network interface are updated."

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
