### PR TITLE
Fix wrong task manager committed section note on introduction-to-the-page-file.md

### DIFF
--- a/support/windows-client/performance/introduction-to-the-page-file.md
+++ b/support/windows-client/performance/introduction-to-the-page-file.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction to the page file
 description: Learn about the page files in Windows. A page file is an optional, hidden system file on a hard disk.
-ms.date: 12/26/2023
+ms.date: 06/11/2024
 ms.topic: troubleshooting
 manager: dcscontentpm
 ms.collection: highpri

--- a/support/windows-client/performance/introduction-to-the-page-file.md
+++ b/support/windows-client/performance/introduction-to-the-page-file.md
@@ -60,7 +60,7 @@ The system commit memory limit is the sum of physical memory and all page files 
 :::image type="content" source="media/introduction-to-the-page-file/task-manager-system-commit-memory.png" alt-text="Screenshot of Task Manager showing the committed bytes and the commit limit.":::
 
 > [!NOTE]
-> In the screenshot, the committed bytes (RAM+Pagefile in use currently) is 6.8 GB and the commit limit (RAM+Pagefile total) is 37.7 GB.
+> In the screenshot, the committed bytes (Pagefile in use currently) is 6.8 GB and the commit limit (Pagefile max size) is 37.7 GB.
 
 The system commit charge is the total committed or "promised" memory of all committed virtual memory in the system. If the system commit charge reaches the system commit limit, the system and processes might not get committed memory. This condition can cause freezing, crashing, and other malfunctions. Therefore, make sure that you set the system commit limit high enough to support the system commit charge during peak usage.
 


### PR DESCRIPTION

![gambar](https://github.com/MicrosoftDocs/SupportArticles-docs/assets/86765295/bece33ed-21b8-4269-a6ca-2bd002bca373)
The committed section on Task Manager Performance Tab is showing information about how much Pagefile In Use / Pagefile Max Size. See the output of `systeminfo` command on the left conhost window.
# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
