### PR TITLE
Fix a broken note

### DIFF
--- a/support/windows-server/remote/troubleshoot-rds-licensing-guidance.md
+++ b/support/windows-server/remote/troubleshoot-rds-licensing-guidance.md
@@ -98,7 +98,7 @@ Registry values:
 - LicenseServers
 - LicensingMode
 
-> [!Notes]
+> [!Note]
 >
 > - This configuration will apply before the one that's mentioned in "Using GUI." This means that the "Using GUI" configuration will have no effect when a local policy is configured because the registry values will not be taken into account. In this situation, you can't use RDSM to configure the license servers and licensing mode.
 > - The gpedit.msc console that's started on the session host server does not appear in this configuration.


### PR DESCRIPTION
There is a broken note in [Using GPO](https://learn.microsoft.com/en-us/troubleshoot/windows-server/remote/troubleshoot-rds-licensing-guidance#using-gpo).

![image](https://github.com/MicrosoftDocs/SupportArticles-docs/assets/5432776/f72a06c4-95a5-4846-9906-93d3e27de1f7)

The valid syntax for a Learn alert of type "Note" is `> [!NOTE]` not `> [!NOTES]`

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
