### PR TITLE
Update tcpip-addressing-and-subnetting.md

### DIFF
--- a/support/windows-client/networking/tcpip-addressing-and-subnetting.md
+++ b/support/windows-client/networking/tcpip-addressing-and-subnetting.md
@@ -72,9 +72,9 @@ Internet RFC 1878 (available from [InterNIC-Public Information Regarding Interne
 
 ## Network classes
 
-Internet addresses are allocated by the [InterNIC](https://www.internic.net), the organization that administers the Internet. These IP addresses are divided into classes. The most common of them are classes A, B, and C. Classes D and E exist, but aren't used by end users. Each of the address classes has a different default subnet mask. You can identify the class of an IP address by looking at its first octet. Following are the ranges of Class A, B, and C Internet addresses, each with an example address:
+Internet addresses are allocated by the [InterNIC](https://www.internic.net), the organization that administers the Internet. These IP addresses are divided into classes. The most common of them are classes A, B, and C. Classes D and E exist, but aren't used by end users. Each of the address classes has a different default subnet mask. You can identify the class of an IP address by looking at its first octet. Following are the ranges of Class A, B, and C IP addresses, each with an example address:
 
-- Class A networks use a default subnet mask of 255.0.0.0 and have 0-127 as their first octet. The address 10.52.36.11 is a class A address. Its first octet is 10, which is between 1 and 126, inclusive.
+- Class A networks use a default subnet mask of 255.0.0.0 and have 0-127 as their first octet. The address 10.52.36.11 is a class A address. Its first octet is 10, which is between 0 and 127, inclusive.
 
 - Class B networks use a default subnet mask of 255.255.0.0 and have 128-191 as their first octet. The address 172.16.52.63 is a class B address. Its first octet is 172, which is between 128 and 191, inclusive.
 


### PR DESCRIPTION
Internet to IP for classes of addresses, as not all of the Classful IP ranges are 'internet routable', RFC 1918 ranges to be specfic

Fix the ranges for classful IPs Class A is 0-127. not 1-126, otherwise the 127 IP range is left out, even though the 127.x.x.x is reserved for loopback that is not relevant to the MATH related to classful IP ranges and the subnet mask.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
