### PR TITLE
Update capture-tcp-dump-linux-node-aks.md

### DIFF
--- a/support/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks.md
+++ b/support/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks.md
@@ -99,6 +99,9 @@ node-debugger-aks-nodepool1-38878740-vmss000000-jfsq2   1/1     Running   0     
 
 The helper pod has a prefix of `node-debugger-aks`, as shown in the third row. Replace the pod name, and then run the following kubectl command. These commands retrieve the packet capture for your Linux node.
 
+> [!NOTE]
+> If the command ```chroot /host``` was used when entering the debug pod, add ```/host``` in front of ```/capture.cap``` for the source file.
+
 ```bash
 kubectl cp node-debugger-aks-nodepool1-38878740-vmss000000-jfsq2:/capture.cap capture.cap
 ```

--- a/support/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks.md
+++ b/support/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks.md
@@ -1,9 +1,9 @@
 ---
 title: Capture a TCP dump from a Linux node in an AKS cluster
 description: Understand how to capture a TCP dump from a Linux node within an Azure Kubernetes Service (AKS) cluster.
-ms.date: 09/13/2024
+ms.date: 09/26/2024
 ms.topic: how-to
-ms.reviewer: erbookbi, amaljuna, kuzhao, v-leedennis
+ms.reviewer: erbookbi, amaljuna, kuzhao, v-rekhanain, v-leedennis, v-weizhu
 ms.service: azure-kubernetes-service
 ms.custom: sap:Monitoring and Logging, linux-related-content
 ---
@@ -99,12 +99,11 @@ node-debugger-aks-nodepool1-38878740-vmss000000-jfsq2   1/1     Running   0     
 
 The helper pod has a prefix of `node-debugger-aks`, as shown in the third row. Replace the pod name, and then run the following kubectl command. These commands retrieve the packet capture for your Linux node.
 
-> [!NOTE]
-> If the command ```chroot /host``` was used when entering the debug pod, add ```/host``` in front of ```/capture.cap``` for the source file.
-
 ```bash
 kubectl cp node-debugger-aks-nodepool1-38878740-vmss000000-jfsq2:/capture.cap capture.cap
 ```
+> [!NOTE]
+> If the command `chroot /host` is used when entering the debug pod, add `/host` in front of `/capture.cap` for the source file.
 
 [!INCLUDE [Third-party disclaimer](../../../includes/third-party-disclaimer.md)]
 

--- a/support/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks.md
+++ b/support/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks.md
@@ -103,7 +103,7 @@ The helper pod has a prefix of `node-debugger-aks`, as shown in the third row. R
 kubectl cp node-debugger-aks-nodepool1-38878740-vmss000000-jfsq2:/capture.cap capture.cap
 ```
 > [!NOTE]
-> If the command `chroot /host` is used when entering the debug pod, add `/host` in front of `/capture.cap` for the source file.
+> If the `chroot /host` command was used when entering the debug pod, add `/host` before `/capture.cap` for the source file.
 
 [!INCLUDE [Third-party disclaimer](../../../includes/third-party-disclaimer.md)]
 


### PR DESCRIPTION
in the section: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/logs/capture-tcp-dump-linux-node-aks#step-5-transfer-the-capture-locally

the "kubectl cp" command assumes the file is located in the root path. adding a NOTE that mentions that the path may begin with "/host" if a "chroot /host" command was done when entering the debug pod.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
