### PR TITLE
Update how-to-use-perfInsights-linux.md

### DIFF
--- a/support/azure/virtual-machines/linux/how-to-use-perfInsights-linux.md
+++ b/support/azure/virtual-machines/linux/how-to-use-perfInsights-linux.md
@@ -12,7 +12,7 @@ ms.collection: linux
 ms.workload: infrastructure-services
 ms.tgt_pltfrm: vm-linux
 ms.topic: troubleshooting
-ms.date: 05/14/2024
+ms.date: 12/04/2024
 ms.author: genli
 ---
 # Troubleshoot Linux virtual machine performance issues with Performance Diagnostics (PerfInsights)
@@ -214,6 +214,8 @@ The following categories of rules are currently supported:
 >[`*`] The HPC scenario relies on the [HPCDiag](https://aka.ms/hpcdiag) tool, so check its support matrix for supported VM sizes and OSes. In particular, NDv4 size VMs aren't yet supported and reports for those VMs may show extraneous findings.
 
 ### Known issues
+
+- RHEL 8 doesn't have Python installed by default because both Python 2 and Python 3.6 are available. To install Python 3.6, run the `yum install python3` command.
 
 - Guest Agent information collection may fail on CentOS 6.x.
 

--- a/support/azure/virtual-machines/linux/how-to-use-perfInsights-linux.md
+++ b/support/azure/virtual-machines/linux/how-to-use-perfInsights-linux.md
@@ -215,8 +215,6 @@ The following categories of rules are currently supported:
 
 ### Known issues
 
-- RHEL 8 does not have Python installed by default. To run PerfInsights Linux, you must first install Python 3.6 or a later version.
-
 - Guest Agent information collection may fail on CentOS 6.x.
 
 - PCI devices information is not collected on Debian based distributions.


### PR DESCRIPTION
This statement under Known issues is False:

"RHEL 8 does not have Python installed by default. To run PerfInsights Linux, you must first install Python 3.6 or a later version."

If Python was not installed by default, Linux agent, dnf etc. would not work.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
