### PR TITLE
Adding alternative way to collect SDK logs using env variables

### DIFF
--- a/support/azure/azure-monitor/app-insights/telemetry/opentelemetry-troubleshooting-nodejs.md
+++ b/support/azure/azure-monitor/app-insights/telemetry/opentelemetry-troubleshooting-nodejs.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot OpenTelemetry issues in Node.js
 description: Learn how to troubleshoot OpenTelemetry issues in Node.js. View known issues that involve Azure Monitor OpenTelemetry Exporters.
-ms.date: 06/24/2024
+ms.date: 11/08/2024
 editor: v-jsitser
 ms.service: azure-monitor
 ms.devlang: javascript
@@ -27,7 +27,7 @@ const provider = new NodeTracerProvider();
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL);
 provider.register();
 ```
-Alternatively, the following [environment variables](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-opentelemetry/README.md#self-diagnostics) can also be used:
+Alternatively, you can use the following [environment variables](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-opentelemetry/README.md#self-diagnostics):
 
 ```javascript
 import { useAzureMonitor } from "@azure/monitor-opentelemetry";

--- a/support/azure/azure-monitor/app-insights/telemetry/opentelemetry-troubleshooting-nodejs.md
+++ b/support/azure/azure-monitor/app-insights/telemetry/opentelemetry-troubleshooting-nodejs.md
@@ -27,6 +27,19 @@ const provider = new NodeTracerProvider();
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL);
 provider.register();
 ```
+Alternatively, the following [environment variables](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-opentelemetry/README.md#self-diagnostics) can also be used:
+
+```javascript
+import { useAzureMonitor } from "@azure/monitor-opentelemetry";
+import { DiagLogLevel } from "@opentelemetry/api";
+
+process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "VERBOSE";
+process.env.APPLICATIONINSIGHTS_LOG_DESTINATION = "file";
+process.env.APPLICATIONINSIGHTS_LOGDIR = "C:/applicationinsights/logs";
+
+useAzureMonitor();
+```
+
 
 ### Step 2: Test connectivity between your application host and the ingestion service
 

--- a/support/azure/azure-monitor/app-insights/telemetry/opentelemetry-troubleshooting-nodejs.md
+++ b/support/azure/azure-monitor/app-insights/telemetry/opentelemetry-troubleshooting-nodejs.md
@@ -5,7 +5,7 @@ ms.date: 11/08/2024
 editor: v-jsitser
 ms.service: azure-monitor
 ms.devlang: javascript
-ms.reviewer: mmcc, lechen, aaronmax, v-leedennis
+ms.reviewer: mmcc, lechen, aaronmax, didiergbenou, v-leedennis, v-weizhu
 ms.custom: sap:Missing or Incorrect data after enabling Application Insights in Azure Portal
 ---
 


### PR DESCRIPTION
Adding an alternative way to collect the SDK logs documented on our GitHub page below:

https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-opentelemetry/README.md#self-diagnostics

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
