### PR TITLE
fix: Escape slash before dot

### DIFF
--- a/support/windows-server/active-directory/disable-and-replace-tls-1dot0.md
+++ b/support/windows-server/active-directory/disable-and-replace-tls-1dot0.md
@@ -60,10 +60,10 @@ ADFS is developed by using Microsoft .NET Framework. For .NET applications to su
 >
 >    Examples of subkeys for this new registry key:
 >
->   - [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v2.0.50727] SchUseStrongCrypto=dword:00000001
->   - [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v4.0.30319] SchUseStrongCrypto=dword:00000001
->   - [HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319] SchUseStrongCrypto=dword:00000001
->   - [HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727] SchUseStrongCrypto=dword:00000001
+>   - [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\v2.0.50727] SchUseStrongCrypto=dword:00000001
+>   - [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\v4.0.30319] SchUseStrongCrypto=dword:00000001
+>   - [HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\\.NETFramework\v4.0.30319] SchUseStrongCrypto=dword:00000001
+>   - [HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\\.NETFramework\v2.0.50727] SchUseStrongCrypto=dword:00000001
 >
 > - To apply the change, you must restart the following services and applications:
 >   - ADFS Service (adfssrv)


### PR DESCRIPTION
The registry keys are missing a slash between the vendor (Microsoft) and the product (.Net framework) .

Why Markdown insists on having an extra slash I don't know?

`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v2.0.50727`
gets rendered as HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v2.0.50727 ❌
`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\v2.0.50727`
gets rendered as HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\v2.0.50727 ✅
 

![image](https://github.com/user-attachments/assets/e155a947-a680-4cd5-a55c-51390abcf3d6)
