### PR TITLE
Update errors-arfter-restricting-egress-traffic.md

### DIFF
--- a/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
+++ b/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
@@ -5,7 +5,7 @@ ms.date: 11/12/2024
 ms.reviewer: chiragpa, nickoman, v-leedennis
 ms.service: azure-kubernetes-service
 keywords:
-#Customer intent: As an Azure Kubernetes user, I want to troubleshoot errors that occur after I restrict egress traffic so that I can access my Azure Kubernetes Service (AKS) cluster successfully.
+#Customer intent: As an Azure Kubernetes user, I want to troubleshoot errors that occur after I restrict egress traffic so that I can access my AKS cluster successfully.
 ms.custom: sap:Connectivity
 ---
 # Errors after restricting egress traffic in AKS
@@ -18,7 +18,7 @@ Certain commands of the [kubectl](https://kubernetes.io/docs/reference/kubectl/)
 
 ## Cause
 
-When you restrict egress traffic from an AKS cluster, there are [required Outbound network and FQDN rules for AKS clusters](/azure/aks/outbound-rules-control-egress). If your settings are in conflict with any of these rules, the symptoms of egress traffic restriction issues will occur.
+When you restrict egress traffic from an AKS cluster, your settings must comply with [required Outbound network and FQDN rules for AKS clusters](/azure/aks/outbound-rules-control-egress). If your settings are in conflict with any of these rules, the symptoms of egress traffic restriction issues occur.
 
 ## Solution
 
@@ -30,7 +30,7 @@ Verify that your configuration doesn't conflict with any of the [required Outbou
 - Application rules
 
 > [!NOTE]
-> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. The lack of static addresses means you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
+> The AKS outbound dependencies are almost entirely defined for FQDNs. These names don't have static addresses behind them. The lack of static addresses means that you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
 
 ## More information
 

--- a/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
+++ b/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
@@ -30,7 +30,7 @@ Verify that your configuration doesn't conflict with any of the [required Outbou
 - Application rules
 
 > [!NOTE]
-> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. The lack of static addresses means you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
+> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. So you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
 
 ## More information
 

--- a/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
+++ b/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
@@ -30,7 +30,7 @@ Verify that your configuration doesn't conflict with any of the [required Outbou
 - Application rules
 
 > [!NOTE]
-> The AKS outbound dependencies are almost entirely defined for FQDNs. These names don't have static addresses behind them. The lack of static addresses means that you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
+> The AKS outbound dependencies are almost entirely defined by using FQDNs. These FQDNs don't have static addresses behind them. The lack of static addresses means that you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
 
 ## More information
 

--- a/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
+++ b/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
@@ -30,7 +30,7 @@ Verify that your configuration doesn't conflict with any of the [required Outbou
 - Application rules
 
 > [!NOTE]
-> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. So you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
+> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. The lack of static addresses means you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
 
 ## More information
 

--- a/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
+++ b/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
@@ -1,7 +1,7 @@
 ---
 title: Errors after restricting egress traffic
 description: Troubleshoot errors that occur after you restrict egress traffic from an Azure Kubernetes Service (AKS) cluster.
-ms.date: 05/25/2022
+ms.date: 11/12/2024
 ms.reviewer: chiragpa, nickoman, v-leedennis
 ms.service: azure-kubernetes-service
 keywords:
@@ -14,20 +14,27 @@ This article discusses how to troubleshoot issues that occur after you restrict 
 
 ## Symptoms
 
-Certain commands of the [kubectl](https://kubernetes.io/docs/reference/kubectl/) command-line tool don't work correctly, or you experience errors when you create an AKS cluster.
+Certain commands of the [kubectl](https://kubernetes.io/docs/reference/kubectl/) command-line tool don't work correctly, or you experience errors when you create an AKS cluster or scaling a node pool.
 
 ## Cause
 
-When you restrict egress traffic from an AKS cluster, there are [required and optionally recommended egress traffic settings for AKS](/azure/aks/limit-egress-traffic). If your settings are in conflict with any of these rules, the symptoms of egress traffic restriction issues will occur.
+When you restrict egress traffic from an AKS cluster, there are [required Outbound network and FQDN rules for AKS clusters](/azure/aks/outbound-rules-control-egress). If your settings are in conflict with any of these rules, the symptoms of egress traffic restriction issues will occur.
 
 ## Solution
 
-Verify that your configuration doesn't conflict with any of the [required or optionally recommended settings](/azure/aks/limit-egress-traffic) for the following items:
+Verify that your configuration doesn't conflict with any of the [required Outbound network and FQDN rules for AKS clusters](/azure/aks/outbound-rules-control-egress) for the following items:
 
 - Outbound ports
 - Network rules
 - Fully qualified domain names (FQDNs)
 - Application rules
+
+> [!NOTE]
+> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. The lack of static addresses means you can't use network security groups (NSGs) to lock down the outbound traffic from an AKS cluster.
+
+## More information
+
+- [Limit network traffic with Azure Firewall in AKS clusters](/azure/aks/limit-egress-traffic)
 
 [!INCLUDE [Third-party disclaimer](../../../includes/third-party-disclaimer.md)]
 

--- a/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
+++ b/support/azure/azure-kubernetes/connectivity/errors-arfter-restricting-egress-traffic.md
@@ -14,7 +14,7 @@ This article discusses how to troubleshoot issues that occur after you restrict 
 
 ## Symptoms
 
-Certain commands of the [kubectl](https://kubernetes.io/docs/reference/kubectl/) command-line tool don't work correctly, or you experience errors when you create an AKS cluster or scaling a node pool.
+Certain commands of the [kubectl](https://kubernetes.io/docs/reference/kubectl/) command-line tool don't work correctly, or you experience errors when you create an AKS cluster or scale a node pool.
 
 ## Cause
 
@@ -30,7 +30,7 @@ Verify that your configuration doesn't conflict with any of the [required Outbou
 - Application rules
 
 > [!NOTE]
-> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. The lack of static addresses means you can't use network security groups (NSGs) to lock down the outbound traffic from an AKS cluster.
+> The AKS outbound dependencies are almost entirely defined with FQDNs, which don't have static addresses behind them. The lack of static addresses means you can't use network security groups (NSGs) to restrict outbound traffic from an AKS cluster.
 
 ## More information
 


### PR DESCRIPTION
Content changes for 'Errors after restricting egress traffic in AKS' as part of doc refresh review on 11/12/2024
- Changed the link from '/azure/aks/limit-egress-traffic' to '/azure/aks/outbound-rules-control-egress'. The latter provides required network and fqdn rules for egress lock down.
- Added notes for users who try to use NSG for restricting egress traffic.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
