### PR TITLE
Update create-file-share-failed-storage-account.md

### DIFF
--- a/support/azure/azure-kubernetes/storage/create-file-share-failed-storage-account.md
+++ b/support/azure/azure-kubernetes/storage/create-file-share-failed-storage-account.md
@@ -1,7 +1,7 @@
 ---
 title: Failed to create file share on storage account
 description: Troubleshoot why you can't create a file share on a storage account for an Azure Kubernetes Service (AKS) cluster.
-ms.date: 11/19/2024
+ms.date: 11/20/2024
 ms.reviewer: chiragpa, nickoman, wonkilee, v-leedennis
 ms.service: azure-kubernetes-service
 #Customer intent: As an Azure Kubernetes user, I want to troubleshoot why I can't create a file share on a storage account so that I can do dynamic provisioning on my Azure Kubernetes Service (AKS) cluster.
@@ -13,7 +13,7 @@ This article discusses how to troubleshoot why you can't create a file share on 
 
 ## Symptoms
 
-When you create a file share on a storage account that's used for dynamic provisioning, the PersistentVolumeClaim (PVC) stuck in Pending status. In this case, when you run the `kubectl describe pvc` command, you receive the following error: 
+When you create a file share on a storage account that's used for dynamic provisioning, the PersistentVolumeClaim (PVC) is stuck in the Pending status. In this case, if you run the `kubectl describe pvc` command, you receive the following error: 
 
 > persistentvolume-controller (combined from similar events):
 >
@@ -29,7 +29,7 @@ When you create a file share on a storage account that's used for dynamic provis
 
 ## Cause
 
-The Kubernetes `persistentvolume-controller` isn't on the network that was chosen when the **Allow access from** network setting was enabled for **Selected networks** on the storage account. Expecially, when you specify `useDataPlaneAPI: "true"` on the storage class, the `persistentvolume-controller` use data plane API for file share create/delete/resize, however, this will fail when there is a firewall or virtual network setting on the storage account.
+The Kubernetes `persistentvolume-controller` isn't on the network that was chosen when the **Allow access from** network setting was enabled for **Selected networks** on the storage account. Especially, when you specify `useDataPlaneAPI: "true"` on the storage class, the `persistentvolume-controller` uses the data plane API for file share creation/deletion/resizing. However, this will fail when a firewall or virtual network is set on the storage account.
 
 ## Workaround
 

--- a/support/azure/azure-kubernetes/storage/create-file-share-failed-storage-account.md
+++ b/support/azure/azure-kubernetes/storage/create-file-share-failed-storage-account.md
@@ -2,7 +2,7 @@
 title: Failed to create file share on storage account
 description: Troubleshoot why you can't create a file share on a storage account for an Azure Kubernetes Service (AKS) cluster.
 ms.date: 11/19/2024
-ms.reviewer: chiragpa, nickoman, v-leedennis
+ms.reviewer: chiragpa, nickoman, wonkilee, v-leedennis
 ms.service: azure-kubernetes-service
 #Customer intent: As an Azure Kubernetes user, I want to troubleshoot why I can't create a file share on a storage account so that I can do dynamic provisioning on my Azure Kubernetes Service (AKS) cluster.
 ms.custom: sap:Storage
@@ -13,8 +13,7 @@ This article discusses how to troubleshoot why you can't create a file share on 
 
 ## Symptoms
 
-PVC status stuck in Pending when AKS creates a file share.
-You receive the following error when `kubectl describe pvc`:
+When you create a file share on a storage account that's used for dynamic provisioning, the PersistentVolumeClaim (PVC) stuck in Pending status. In this case, when you run the `kubectl describe pvc` command, you receive the following error: 
 
 > persistentvolume-controller (combined from similar events):
 >
@@ -30,11 +29,10 @@ You receive the following error when `kubectl describe pvc`:
 
 ## Cause
 
-The Kubernetes `persistentvolume-controller` isn't on the network that was chosen when the **Allow access from** network setting was enabled for **Selected networks** on the storage account.
-Expecially, when user specifies `useDataPlaneAPI: "true"` on storage class, the persistentvolume-controller use data plane API for file share create/delete/resize, while it would fail when there is firewall or vnet setting on storage account.
+The Kubernetes `persistentvolume-controller` isn't on the network that was chosen when the **Allow access from** network setting was enabled for **Selected networks** on the storage account. Expecially, when you specify `useDataPlaneAPI: "true"` on the storage class, the `persistentvolume-controller` use data plane API for file share create/delete/resize, however, this will fail when there is a firewall or virtual network setting on the storage account.
 
 ## Workaround
 
-Creating a file share with dynamic provisioning would fail, so create a file share and set up your AKS cluster to use [static provisioning with Azure Files](/azure/aks/azure-files-volume).
+Create a file share and set up your AKS cluster to use [static provisioning with Azure Files](/azure/aks/azure-files-volume).
 
 [!INCLUDE [Azure Help Support](../../../includes/azure-help-support.md)]

--- a/support/azure/azure-kubernetes/storage/create-file-share-failed-storage-account.md
+++ b/support/azure/azure-kubernetes/storage/create-file-share-failed-storage-account.md
@@ -1,7 +1,7 @@
 ---
 title: Failed to create file share on storage account
 description: Troubleshoot why you can't create a file share on a storage account for an Azure Kubernetes Service (AKS) cluster.
-ms.date: 05/25/2022
+ms.date: 11/19/2024
 ms.reviewer: chiragpa, nickoman, v-leedennis
 ms.service: azure-kubernetes-service
 #Customer intent: As an Azure Kubernetes user, I want to troubleshoot why I can't create a file share on a storage account so that I can do dynamic provisioning on my Azure Kubernetes Service (AKS) cluster.
@@ -9,11 +9,12 @@ ms.custom: sap:Storage
 ---
 # Failed to create file share on storage account
 
-This article discusses how to troubleshoot why you can't create a file share on a storage account that's used for dynamic provisioning on Microsoft Azure Kubernetes Service (AKS).
+This article discusses how to troubleshoot why you can't create a file share on a storage account that's used for dynamic provisioning on Azure Kubernetes Service (AKS).
 
 ## Symptoms
 
-You receive the following error when AKS creates a file share:
+PVC status stuck in Pending when AKS creates a file share.
+You receive the following error when `kubectl describe pvc`:
 
 > persistentvolume-controller (combined from similar events):
 >
@@ -30,9 +31,10 @@ You receive the following error when AKS creates a file share:
 ## Cause
 
 The Kubernetes `persistentvolume-controller` isn't on the network that was chosen when the **Allow access from** network setting was enabled for **Selected networks** on the storage account.
+Expecially, when user specifies `useDataPlaneAPI: "true"` on storage class, the persistentvolume-controller use data plane API for file share create/delete/resize, while it would fail when there is firewall or vnet setting on storage account.
 
 ## Workaround
 
-Set up your AKS cluster to use [static provisioning with Azure Files](/azure/aks/azure-files-volume).
+Creating a file share with dynamic provisioning would fail, so create a file share and set up your AKS cluster to use [static provisioning with Azure Files](/azure/aks/azure-files-volume).
 
 [!INCLUDE [Azure Help Support](../../../includes/azure-help-support.md)]


### PR DESCRIPTION
Content changes for 'Failed to create file share on storage account' as part of doc refresh review on 11/19/2024
- Described in details when the customer encounter this error.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
