### PR TITLE
sids-not-resolve-into-friendly-names.md: correct capitalisation

### DIFF
--- a/support/windows-server/windows-security/sids-not-resolve-into-friendly-names.md
+++ b/support/windows-server/windows-security/sids-not-resolve-into-friendly-names.md
@@ -14,7 +14,7 @@ searchScope:
 ---
 # Some SIDs don't resolve into friendly names
 
-This article provides some information about the issue where some security identifiers (SIDS) don't resolve into friendly names.
+This article provides some information about the issue where some security identifiers (SIDs) don't resolve into friendly names.
 
 _Original KB number:_ &nbsp; 4502539
 
@@ -43,7 +43,7 @@ Windows 10, version 1809 uses more than 300 Capability SIDs.
 ## More information
 
 > [!Important]
-> Don't delete Capability SIDS from either the registry or file system permissions. Removing a Capability SID from file system permissions or registry permissions might cause a feature or application to function incorrectly. After you remove a Capability SID, you cannot use the UI to add it back.
+> Don't delete Capability SIDs from either the registry or file system permissions. Removing a Capability SID from file system permissions or registry permissions might cause a feature or application to function incorrectly. After you remove a Capability SID, you cannot use the UI to add it back.
 
 When you're troubleshooting an unresolved SID, make sure that it isn't a Capability SID. To get a list of all of the Capability SIDs, follow these steps:
 


### PR DESCRIPTION
In the abbreviation/acronym "SID" for "Security IDentifier", the correct capitalisation of the plural is "SIDs" not "SIDS".
This article already had it correct in several places, but there were a couple of places where the incorrect capitalisation was used. This PR fixes that.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
