### PR TITLE
Update poor-performance-calling-lookup-functions.md

### DIFF
--- a/support/windows-server/active-directory/poor-performance-calling-lookup-functions.md
+++ b/support/windows-server/active-directory/poor-performance-calling-lookup-functions.md
@@ -1,7 +1,7 @@
 ---
 title: How to disable the lookup of isolated names
 description: Provides a resolution to the poor performance when calling lookup functions to resolve names. Gives a method to disable the lookup of isolated names in trusted domain.
-ms.date: 01/15/2025
+ms.date: 02/06/2025
 manager: dcscontentpm
 audience: itpro
 ms.topic: troubleshooting

--- a/support/windows-server/active-directory/poor-performance-calling-lookup-functions.md
+++ b/support/windows-server/active-directory/poor-performance-calling-lookup-functions.md
@@ -16,7 +16,7 @@ When calling the **LookupAccountName** or **LsaLookupNames** function to resolve
 
 For example, poor performance might occur when using scripts or tools (such as *Cacls.exe*, *Xcacls.exe*, *icacls.exe*, *Dsacls.exe*, and *Subinacl.exe*) to call the functions to edit security settings.
 
-The problem may show up when you have many trusted domains or forests (applies to both external and forest trusts), and/or some of these domains or forests are offline or slow to respond.
+The problem may show up when you have many trusted domains or external forest trusts, and/or some of these domains or forests are offline or slow to respond.
 
 When the functions are called for an isolated name (the format is AccountName in contrast to domain\AccountName), a remote procedure call (RPC) is made to domain controllers on all trusted domains/forests. This issue might occur if the primary domain has many trust relationships with other domains/forests or if it's doing many lookups at a same time. For example, a script is configured to run at the startup of many clients, or many trusted domains/forests use the same script simultaneously.
 


### PR DESCRIPTION
according to code review for LsaDbpLookupNamesBuildWorkList, the forest trust won't be used for isolated name lookup, as long as the trust has the attribute TRUST_ATTRIBUTE_FOREST_TRANSITIVE.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
