### PR TITLE
Update vm-extension-provisioning-errors.md

### DIFF
--- a/support/azure/virtual-machine-scale-sets/extensions/vm-extension-provisioning-errors.md
+++ b/support/azure/virtual-machine-scale-sets/extensions/vm-extension-provisioning-errors.md
@@ -18,6 +18,9 @@ This article provides guidance on resolving **VMExtensionProvisioningError**, **
 > [!NOTE]
 > In the context of Virtual Machine Scale Sets, the "VM" in these errors messages refers to an instance within a specific Virtual Machine Scale Set.
 
+> [!NOTE]
+>In some circumstances Instance VM scalein for VMSS, virtual machine deployment will fail with the message "OSProvisioningTimedOut". Most of the time, the virtual machine should be started and the operating system running. The Guest Agent should often report status as well.This error appears usually when the Provisioning Agent or the Guest Agent can't send status back to CRP but the virtual machine has been created and the operating system started. The timeout set for CRP to wait for the VM Guest OS to send a healthy signal is 40 minutes, if the VM Deployed includes Extensions the timeout is extended to wait for 90 minutes. This time might change at any time.
+
 ## Symptoms
 
 You see **VMExtensionProvisioningError**, **VMExtensionHandlerNonTransientError**, or **VMExtensionProvisioningTimeout** errors, as in the following examples:


### PR DESCRIPTION
When troubleshooting a case, I got into scenario where cx encountered OSProvisioningTimedOut for VMSS SCALE-in and cx referred our MS public doc to exactly check what would be timeout period and cx could not find any MS Public doc mentioning it and cx is very upset that our doc is not properly updated as this is very common error scenario .

So updated the public doc with below info with 2 scenarios of timeout periods as well which would be helpful for any cx's checking the same.



In some circumstances Instance VM scalein for VMSS, virtual machine deployment will fail with the message "OSProvisioningTimedOut". Most of the time, the virtual machine should be started and the operating system running. The Guest Agent should often report status as well.This error appears usually when the Provisioning Agent or the Guest Agent can't send status back to CRP but the virtual machine has been created and the operating system started. The timeout set for CRP to wait for the VM Guest OS to send a healthy signal is 40 minutes, if the VM Deployed includes Extensions the timeout is extended to wait for 90 minutes. This time might change at any time.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
