### PR TITLE
Fix stray colons at end of image

### DIFF
--- a/support/mem/intune/device-enrollment/troubleshoot-windows-auto-enrollment.md
+++ b/support/mem/intune/device-enrollment/troubleshoot-windows-auto-enrollment.md
@@ -21,7 +21,7 @@ Before you start troubleshooting, it's best to verify that everything is configu
 
 - Verify that auto-enrollment is enabled for all users who will enroll the devices in Intune. For more information, see [Microsoft Entra ID and Microsoft Intune: Automatic MDM enrollment in the new Portal](/windows/client-management/mdm/azure-ad-and-microsoft-intune-automatic-mdm-enrollment-in-the-new-portal).
 
-  :::image type="content" source="media/troubleshoot-windows-auto-enrollment/verify-auto-enrollment.png" alt-text="Screenshot shows options to verify auto-enrollment." lightbox="media/troubleshoot-windows-auto-enrollment/verify-auto-enrollment.png"::::::
+  :::image type="content" source="media/troubleshoot-windows-auto-enrollment/verify-auto-enrollment.png" alt-text="Screenshot shows options to verify auto-enrollment." lightbox="media/troubleshoot-windows-auto-enrollment/verify-auto-enrollment.png":::
 
   - Verify that **MDM user scope** is set to **All** to allow all users to enroll a device in Intune.
   - Verify that **MAM User scope** is set to **None**. Otherwise, this setting will have precedence over the MDM scope and cause issues.

--- a/support/windows-client/performance/troubleshooting-slow-file-copying-in-windows.md
+++ b/support/windows-client/performance/troubleshooting-slow-file-copying-in-windows.md
@@ -82,7 +82,7 @@ To resolve this issue, follow these steps on the client computer that has the pr
 1. Make sure that the workstation service is running.
 1. Make sure that **client for Microsoft networking** is selected in the network connection properties.  
 
-   :::image type="content" source="media/troubleshooting-slow-file-copying-in-windows/client-microsoft-networks.png" alt-text="Screenshot of the Local Area Connection Properties dialog, in which the Client for Microsoft Networks item is selected." border="false"::::
+   :::image type="content" source="media/troubleshooting-slow-file-copying-in-windows/client-microsoft-networks.png" alt-text="Screenshot of the Local Area Connection Properties dialog, in which the Client for Microsoft Networks item is selected." border="false":::
 
 ## Server-side troubleshooting
 
@@ -103,5 +103,3 @@ How to determine the referral DFS server to which the clients are connecting:
 2. On the **DFS** tab, check the referral list. The current DFS server is marked as active. In the following example, the client is connecting to the server HAOMS1. 
  
    :::image type="content" source="media/troubleshooting-slow-file-copying-in-windows/referral-list.png" alt-text="Screenshot of the DFS tab in the shared folder properties window on a client computer, which shows the UNC path in Referral list.":::
-
-


### PR DESCRIPTION
Summary:
- Remove extraneous trailing colons at the end of image embeds that renders as stray colons
- Clean up multiple ending empty lines