### PR TITLE
adding missing resource group parameter in az vm repair command

### DIFF
--- a/support/azure/virtual-machines/linux/linux-virtual-machine-cannot-start-fstab-errors.md
+++ b/support/azure/virtual-machines/linux/linux-virtual-machine-cannot-start-fstab-errors.md
@@ -115,7 +115,7 @@ The ALAR scripts use the repair extension `repair-button` to fix fstab issues by
 ```azurecli-interactive
 az extension add -n vm-repair
 az extension update -n vm-repair
-az vm repair repair-button --button-command 'fstab' --verbose $RGNAME --name $VMNAME
+az vm repair repair-button --button-command 'fstab' --verbose --resource-group $RGNAME --name $VMNAME
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The resource group parameter (--resource-group |  -g ) was missing on the command

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
