### PR TITLE
Update Application routing add-on link as HTTP application routing add-on has retired.

### DIFF
--- a/support/azure/azure-kubernetes/load-bal-ingress-c/create-unmanaged-ingress-controller.md
+++ b/support/azure/azure-kubernetes/load-bal-ingress-c/create-unmanaged-ingress-controller.md
@@ -1,11 +1,11 @@
 ---
 title: Create an unmanaged ingress controller
 description: Learn how to create and configure an ingress controller in an Azure Kubernetes Service (AKS) cluster.
-ms.reviewer: allensu, v-rekhanain, v-weizhu
+ms.reviewer: allensu, v-rekhanain, jamielo, v-weizhu
 ms.service: azure-kubernetes-service
 ms.custom: sap:Load balancer and Ingress controller
 ms.topic: how-to
-ms.date: 10/17/2024
+ms.date: 03/10/2025
 ---
 # Create an unmanaged ingress controller
 
@@ -574,7 +574,7 @@ Alternatively, a more granular approach is to delete the individual resources cr
 
 To configure TLS with your existing ingress components, see [Use TLS with an ingress controller](/previous-versions/azure/aks/ingress-tls).
 
-To configure your AKS cluster to use Application routing, see [Application routing add-on](/azure/aks/app-routing).
+To configure your AKS cluster to use application routing, see [Application routing add-on](/azure/aks/app-routing).
 
 This article included some external components to AKS. To learn more about these components, see the following project pages:
 

--- a/support/azure/azure-kubernetes/load-bal-ingress-c/create-unmanaged-ingress-controller.md
+++ b/support/azure/azure-kubernetes/load-bal-ingress-c/create-unmanaged-ingress-controller.md
@@ -574,7 +574,7 @@ Alternatively, a more granular approach is to delete the individual resources cr
 
 To configure TLS with your existing ingress components, see [Use TLS with an ingress controller](/previous-versions/azure/aks/ingress-tls).
 
-To configure your AKS cluster to use HTTP application routing, see [Enable the HTTP application routing add-on](/previous-versions/azure/aks/http-application-routing).
+To configure your AKS cluster to use Application routing, see [Application routing add-on](/azure/aks/app-routing).
 
 This article included some external components to AKS. To learn more about these components, see the following project pages:
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/SupportArticles-docs/blob/cb8c3eb8308c06034e9bfa1810d2fa4b93325a24/support/azure/azure-kubernetes/load-bal-ingress-c/create-unmanaged-ingress-controller.md?plain=1#L577

HTTP application routing add-on has retired on March 03, 2025. The replacement is [Application Routing add-on](https://learn.microsoft.com/en-us/azure/aks/app-routing).

Suggest changing to:
"To configure your AKS cluster to use Application routing, see [Application Routing add-on](https://learn.microsoft.com/en-us/azure/aks/app-routing)."

Ref: [Retirement: HTTP application routing add-on (preview) for AKS will retire 03/03/2025](https://azure.microsoft.com/en-us/updates?id=retirement-http-application-routing-addon-preview-for-aks-will-retire-03032025)