### PR TITLE
Manually_Uninstall_Reinstall_Azure_VM_Agent

### DIFF
--- a/support/azure/virtual-machines/windows/windows-azure-guest-agent.md
+++ b/support/azure/virtual-machines/windows/windows-azure-guest-agent.md
@@ -7,7 +7,7 @@ ms.collection: windows
 author: kegregoi
 ms.tgt_pltfrm: vm-windows
 ms.workload: infrastructure
-ms.date: 07/21/2023
+ms.date: 03/17/2025
 ms.author: kegregoi
 editor: v-jsitser
 ms.reviewer: v-leedennis, scotro
@@ -145,7 +145,7 @@ Manually uninstall the Azure VM Agent, and then reinstall it by following these 
 
 1. Under *C:\\WindowsAzure*, create a folder that's named *OLD*.
 1. Move any folders that are named *Packages* or *GuestAgent* to the *OLD* folder. Also, move any of the *GuestAgent* folders in *C:\\WindowsAzure\\logs* that start as *GuestAgent_x.x.xxxxx* to the *OLD* folder.
-1. Download and install the latest version of the Windows Installer ([MSI](https://github.com/Azure/WindowsVMAgent/releases)) agent from the Github Releases for WinGA. You must have administrator rights to complete the installation.
+1. Download and install the latest version of the Windows Installer (MSI) agent from [the GitHub page for Azure Windows VM Agent releases](https://github.com/Azure/WindowsVMAgent/releases). You must have administrator rights to complete the installation.
 1. Install Guest Agent by running the following [msiexec](/windows-server/administration/windows-commands/msiexec) command:
 
     ```cmd

--- a/support/azure/virtual-machines/windows/windows-azure-guest-agent.md
+++ b/support/azure/virtual-machines/windows/windows-azure-guest-agent.md
@@ -145,7 +145,7 @@ Manually uninstall the Azure VM Agent, and then reinstall it by following these 
 
 1. Under *C:\\WindowsAzure*, create a folder that's named *OLD*.
 1. Move any folders that are named *Packages* or *GuestAgent* to the *OLD* folder. Also, move any of the *GuestAgent* folders in *C:\\WindowsAzure\\logs* that start as *GuestAgent_x.x.xxxxx* to the *OLD* folder.
-1. Download and install the latest version of the Windows Installer (MSI) agent. You must have administrator rights to complete the installation.
+1. Download and install the latest version of the Windows Installer ([MSI](https://github.com/Azure/WindowsVMAgent/releases)) agent from the Github Releases for WinGA. You must have administrator rights to complete the installation.
 1. Install Guest Agent by running the following [msiexec](/windows-server/administration/windows-commands/msiexec) command:
 
     ```cmd


### PR DESCRIPTION
In this public document -> https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows/windows-azure-guest-agent#:~:text=Download%20and%20install%20the%20latest%20version%20of%20the%20Windows%20Installer%20(MSI)%20agent.%20You%20must%20have%20administrator%20rights%20to%20complete%20the%20installation.

In cause 2 , solution 2, there is no link provided for customers to download the latest version of the Windows Installer (MSI) agent.

Have added the Github link to download the latest Guest Agent.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
