### PR TITLE
Update mapped-network-drive-fail-reconnect.md

### DIFF
--- a/support/windows-client/networking/mapped-network-drive-fail-reconnect.md
+++ b/support/windows-client/networking/mapped-network-drive-fail-reconnect.md
@@ -51,9 +51,9 @@ while($True){
     foreach( $MappedDrive in $MappedDrives)
     {
         try {
-            New-SmbMapping -LocalPath $MappedDrive.LocalPath -RemotePath $MappedDrive.RemotePath -Persistent $True
+            New-SmbMapping -LocalPath $MappedDrive.LocalPath -RemotePath $MappedDrive.RemotePath -Persistent $True -ErrorAction Stop
         } catch {
-            Write-Host "There was an error mapping $MappedDrive.RemotePath to $MappedDrive.LocalPath"
+            Write-Host "There was an error mapping $($MappedDrive.RemotePath) to $($MappedDrive.LocalPath)"
         }
     }
     $i = $i - 1
@@ -97,3 +97,22 @@ All workarounds should be executed in standard user security context. Executing 
 9. In the **Start in (optional)** field, type the location (_%SystemDrive%\\Scripts\\_) of the script file.
 10. On the **Conditions** tab, select the **Start only if the following network connection is available** option, select **Any connection**, and then select **OK**.
 11. Log off, and then log back on to the device to run the scheduled task.
+
+#### Workaround 3: Create a scheduled task for Microsoft VPN Client EventID 20225(VPN Connection Successfully established)
+
+1. Copy the script file MapDrives.ps1 to the following location:  
+    %SystemDrive%\\Scripts\\  
+2. In **Task Scheduler**, select **Action** > **Create Task**.
+3. On the **General** tab in the **Create Task** dialog box, type a name (such as *Map Network Drives*) and description for the task.
+4. Select **Change User or Group**, select a local user or group (such as **LocalComputer\\Users**) and then select **OK**.
+5. On the **Triggers** tab, select **New**, and then select **On an event** for the **Begin the task** field.
+6. On the **Triggers** tab, select **Log**, and then select **Application** from the **Log** dropdown list.
+7. On the **Triggers** tab, Type **RasClient** for the **Source** field.
+8. On the **Triggers** tab, Type **20225** for the **Event ID** field and then select **OK**.
+9. On the **Actions** tab, select **New**, and then select **Start a program** for the **Action** field.
+10. Type *Powershell.exe* for the **Program/script** field.
+11. In the **Add arguments (optional)** field, type the following:  
+    *-windowsstyle hidden -command .\\MapDrives.ps1 >> %TEMP%\\StartupLog.txt 2>&1*
+12. In the **Start in (optional)** field, type the location (*%SystemDrive%\\Scripts\\*) of the script file.
+13. On the **Conditions** tab, select the **Start only if the following network connection is available** option, select **Any connection**, and then select **OK**.
+14. Log off, and then log back on to the device to run the scheduled task.


### PR DESCRIPTION
Proposing some changes and workaround for this issue.

The desired String output "$Variable.something" will not work unless between parenthesis $() because everything after the . will be interpreted as a string and not as the object inside the property. 

Additional Workaround that is also very effective.

#sign-off

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
