### PR TITLE
Update suse-public-cloud-connectivity-registration-issues.md

### DIFF
--- a/support/azure/virtual-machines/linux/suse-public-cloud-connectivity-registration-issues.md
+++ b/support/azure/virtual-machines/linux/suse-public-cloud-connectivity-registration-issues.md
@@ -1,10 +1,10 @@
 ---
 title: Troubleshoot connectivity and registration for SUSE SLES VMs
 description: Troubleshoot scenarios in which an Azure VM that has a SUSE Linux Enterprise Server image can't connect to the SUSE Subscription Management Tool (SMT) repository.
-ms.date: 02/26/2025
+ms.date: 05/12/2025
 author: rnirek
 ms.author: hokamath
-ms.reviewer: adelgadohell, mahuss, esanchezvela, scotro, v-weizhu, divargas
+ms.reviewer: adelgadohell, mahuss, esanchezvela, scotro, v-weizhu, divargas, vkchilak
 editor: v-jsitser
 ms.service: azure-virtual-machines
 ms.custom: sap:VM Admin - Linux (Guest OS), linux-related-content

--- a/support/azure/virtual-machines/linux/suse-public-cloud-connectivity-registration-issues.md
+++ b/support/azure/virtual-machines/linux/suse-public-cloud-connectivity-registration-issues.md
@@ -219,7 +219,7 @@ If instances aren't regularly updated, they can become incompatible with our upd
 3. Download the following packages:
 
     ```bash
-    sudo zypper --pkg-cache-dir /root/packages/ download cloud-regionsrv-client cloud-regionsrv-client-plugin-azure regionServiceClientConfigAzure python3-azuremetadata SUSEConnect python3-cssselect python3-toml python3-lxml python3-M2Crypto python3-zypp-plugin libsuseconnect suseconnect-ruby-bindings docker libcontainers-common
+    sudo zypper --pkg-cache-dir /root/packages/ download cloud-regionsrv-client cloud-regionsrv-client-plugin-azure regionServiceClientConfigAzure python3-azuremetadata SUSEConnect python3-cssselect python3-toml python3-lxml python3-M2Crypto python3-zypp-plugin libsuseconnect suseconnect-ruby-bindings docker libcontainers-common containerd libcontainers-sles-mounts runc
     ```
 4. Run the following commands:
 


### PR DESCRIPTION
The resolution steps for "Scenario-2" need an update.

There are three more dependency packages which also need to be downloaded and installed. While working on this collab task - 2505050030003666001, I noticed this issue. We need these packages as well to be downloaded: runc, containerd and libcontainers-sles-mounts.

Only after downloading them and moving them to the affected VM, the installation went fine and the subsequently, VM able to establish the registration.

So, I modified the command to include these packages as well to be downloaded. Modified command is mentioned below for ref.:

sudo zypper --pkg-cache-dir /root/packages/ download cloud-regionsrv-client cloud-regionsrv-client-plugin-azure regionServiceClientConfigAzure python3-azuremetadata SUSEConnect python3-cssselect python3-toml python3-lxml python3-M2Crypto python3-zypp-plugin libsuseconnect suseconnect-ruby-bindings docker libcontainers-common containerd libcontainers-sles-mounts runc

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
