### PR TITLE
Update docs for RHEL 10, make cert docs evergreen.

### DIFF
--- a/support/azure/virtual-machines/linux/linux-rhui-connectivity-issues.md
+++ b/support/azure/virtual-machines/linux/linux-rhui-connectivity-issues.md
@@ -89,6 +89,7 @@ This version of the validation script currently supports only the following Red 
 - RHEL 7._x_ PAYG VMs
 - RHEL 8._x_ PAYG VMs
 - RHEL 9._x_ PAYG VMs
+- RHEL 10._x_ PAYG VMs
 
 #### How to run the validation script
 
@@ -110,7 +111,7 @@ To run the validation script, enter the following shell commands on a Red Hat VM
 
   The script will generate a report that identifies any specific issues. The script output is also saved in `/var/log/rhuicheck.log` after execution. You can also inspect that log file separately.
 
-#### [Red Hat 8.x and 9.x](#tab/rhel89)
+#### [Red Hat 8.x, 9.x, and 10.x](#tab/rhel89)
 
 1. If the virtual machine has internet access, execute the script directly from the VM using the following command:
 

--- a/support/azure/virtual-machines/linux/troubleshoot-linux-rhui-certificate-issues.md
+++ b/support/azure/virtual-machines/linux/troubleshoot-linux-rhui-certificate-issues.md
@@ -161,9 +161,22 @@ Install the missing RHUI package for Base RHEL (non-EUS), EUS, or SAP/E4S.
    source /etc/os-release
    MAJOR_VERSION=$(echo $VERSION_ID | cut -d '.' -f 1)
    MINOR_VERSION=$(echo $VERSION_ID | cut -d '.' -f 2)
+   if [ -z "$MAJOR_VERSION" ]; then
+     echo "Could not determine major version. Please stop and check /etc/os-release."
+   fi
    echo $MAJOR_VERSION  # for example "8" or "10"
-   GPG_KEY_SUFFIX=$(if [ $MAJOR_VERSION -eq "10" ]; then echo "-2025"; fi)
-   GPG_KEY="https://packages.microsoft.com/keys/microsoft${GPG_KEY_SUFFIX}.asc"
+
+   if [ "$MAJOR_VERSION" -eq "10" ]; then
+     GPG_KEY="https://packages.microsoft.com/keys/microsoft-2025.asc"
+   else
+     GPG_KEY="https://packages.microsoft.com/keys/microsoft.asc"
+   fi
+   if [ $(curl --silent --head --output /dev/null --write-out "%{http_code}" --location $GPG_KEY) -ne "200" ]; then
+     echo "Error: Unable to fetch GPG key from:"
+     echo "   $GPG_KEY"
+     echo "Please verify internet connectivity."
+     echo "If you must proceed without the GPG key you can set 'gpgcheck=0' below."
+   fi
    ```
 
 3. Set variables depending on your desired product offering. 
@@ -242,7 +255,7 @@ Install the missing RHUI package for Base RHEL (non-EUS), EUS, or SAP/E4S.
 
 4. Ensure previous rhui-azure rpms are cleaned up.
    ```bash
-   sudo dnf remove rhui-azure-*
+   sudo yum remove rhui-azure-*
    ```
 
 5. Create a config file by using this command or a text editor.

--- a/support/azure/virtual-machines/linux/yum-dnf-common-issues.md
+++ b/support/azure/virtual-machines/linux/yum-dnf-common-issues.md
@@ -53,6 +53,7 @@ This version of the check script currently supports only the following Red Hat V
 - RHEL 7._x_ PAYG VMs
 - RHEL 8._x_ PAYG VMs
 - RHEL 9._x_ PAYG VMs
+- RHEL 10._x_ PAYG VMs
 
 #### How to run the RHUI check script
 
@@ -73,7 +74,7 @@ To run the check script, enter the following shell commands on a Red Hat VM:
     ```
 3. The script generates a report that includes any issues that are found. The script output is also saved in `/var/log/rhuicheck.log` after you run it. 
 
-#### [Red Hat 8.x and 9.x](#tab/rhel89)
+#### [Red Hat 8.x, 9.x, and 10.x](#tab/rhel89)
 
 1. If the VM has internet access, run the script directly from the VM by using the following command:
 
@@ -280,7 +281,7 @@ There are two possible solutions: Try to complete the transaction, or manually r
    sudo yum-complete-transaction --cleanup-only
    ```
 
-##### [RHEL/Centos/Oracle Linux 8._x_ and 9._x_](#tab/rhel89)
+##### [RHEL/Centos/Oracle Linux 8._x_, 9._x_, and 10._x_](#tab/rhel89)
 
 1. Try to complete the transaction by running the following [yum history](http://yum.baseurl.org/wiki/YumHistory.html) command:
 
@@ -318,7 +319,7 @@ There are two possible solutions: Try to complete the transaction, or manually r
    sudo yum install kernel-<newversion>-<release>.<arch>
    ```
 
-##### [RHEL/Centos/Oracle Linux 8._x_ and 9._x_](#tab/rhel89)
+##### [RHEL/Centos/Oracle Linux 8._x_, 9._x_, and 10._x_](#tab/rhel89)
 
 1. Back up the */var/lib/dnf* and */etc/dnf\** directories by running the following commands:
 
@@ -409,10 +410,10 @@ If the error typically occurs because an incorrect value is used for */etc/yum/v
 
 2. Determine the current value for the release version by running the following `cat` command.
 
-   | RHEL version | Command                             |
-   |--------------|-------------------------------------|
-   | RHEL 7       | `sudo cat /etc/yum/vars/releasever` |
-   | RHEL 8 and 9 | `sudo cat /etc/dnf/vars/releasever` |
+   | RHEL version      | Command                             |
+   |-------------------|-------------------------------------|
+   | RHEL 7            | `sudo cat /etc/yum/vars/releasever` |
+   | RHEL 8, 9, and 10 | `sudo cat /etc/dnf/vars/releasever` |
 
 3. Modify and use the correct value for the release version:
 
@@ -433,10 +434,10 @@ If the error typically occurs because an incorrect value is used for */etc/yum/v
 
    - If your system is using non-EUS repositories, make sure that you remove the version lock for the */etc/yum/vars/releasever* or */etc/dnf/vars/releasever* file by running the following command.
 
-     | RHEL version | Command                                   |
-     |--------------|-------------------------------------------|
-     | RHEL 7       | `sudo echo "" > /etc/yum/vars/releasever` |
-     | RHEL 8 and 9 | `sudo echo "" > /etc/dnf/vars/releasever` |
+     | RHEL version      | Command                                   |
+     |-------------------|-------------------------------------------|
+     | RHEL 7            | `sudo echo "" > /etc/yum/vars/releasever` |
+     | RHEL 8, 9, and 10 | `sudo echo "" > /etc/dnf/vars/releasever` |
 
 ##### [Oracle Linux](#tab/ol)
 


### PR DESCRIPTION
The intent here is to update docs for RHEL 10. This should be merged along with [this PR](https://github.com/Azure/azure-support-scripts/pull/60) that updates `rhui-check.py` to work properly on RHEL 10.

Along the way I noticed that there was a massive amount of unnecessary duplication in the "Solution 3: Install the EUS, non-EUS, or SAP/E4S RHUI package" section. I have de-duplicated it. The resulting instructions are evergreen and universal, and don't need to be updated when new RHEL 10 offerings are made available (non-Base offerings are not yet published), or other offerings go EOL.