### PR TITLE
Fix PowerShell command for counting pending devices

### DIFF
--- a/support/entra/entra-id/dir-dmns-obj/pending-devices.md
+++ b/support/entra/entra-id/dir-dmns-obj/pending-devices.md
@@ -58,7 +58,7 @@ To fix the problem, unregister the device by running `dsregcmd /leave` at an ele
 1. Count all pending devices:
 
    ```powershell
-   (Get-MgDevice -All -Filter "TrustType eq 'ServerAd'" | Where-Object{((-not $_.AlternativeSecurityIds)}).count
+   (Get-MgDevice -All -Filter "TrustType eq 'ServerAd'" | Where-Object{((-not $_.AlternativeSecurityIds))}).count
    ```
     
     You can also save the returned data in a CSV file:


### PR DESCRIPTION
The Where-object statement for counting pending devices was missing a closing ')' before the closing '}'.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
