### PR TITLE
Change recommended Kerberos encryption value to 0x18

### DIFF
--- a/support/windows-server/windows-security/kerberos-protocol-registry-kdc-configuration-keys.md
+++ b/support/windows-server/windows-security/kerberos-protocol-registry-kdc-configuration-keys.md
@@ -280,7 +280,7 @@ The registry entries that are listed in this section must be added to the follow
   - Default value: 0x27
   - Possible values:
 
-    The default value is 0x27 (DES, RC4, AES session keys). We recommend setting the value to 0x3C for increased security, as this value allows for both AES-encrypted tickets and AES session keys. If you move to an AES-only environment where RC4 isn't used for the Kerberos protocol, we recommend setting the value to 0x38.
+    The default value is 0x27 (DES, RC4, AES session keys). We recommend setting the value to 0x3C for increased security, as this value allows for both AES-encrypted tickets and AES session keys. If you move to an AES-only environment where RC4 isn't used for the Kerberos protocol, we recommend setting the value to 0x18.
 
     This value sets AES as the default encryption type for session keys on accounts that aren't marked with a default encryption type.
 


### PR DESCRIPTION
Updated recommended value for Kerberos encryption type to 0x18 for AES-only environments.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
