### PR TITLE
Update TSG for file share mount failures

### DIFF
--- a/support/azure/azure-kubernetes/storage/file-share-mount-failures-azure-files.md
+++ b/support/azure/azure-kubernetes/storage/file-share-mount-failures-azure-files.md
@@ -39,12 +39,41 @@ Manually update the `azurestorageaccountkey` field in an Azure file secret to ad
 
 1. Change the `azurestorageaccountkey` field to use the new base64-encoded storage account key, and then save the file.
 
-1. Redeploy your pods.
+1. Ensure proper unmount and recovery by using one of the following options. Redeploying pods alone often fails to fix the issue if an existing mount with a stale account key is reused.
 
-> [!NOTE]
-> Simply deleting the pod and allowing it to be re-created might not resolve the issue. Make sure that you redeploy the pod.
+    **Option A: Cordon the node (single pod/node scenario)**
 
-After a few minutes, the agent node will retry the Azure File mount operation by using the updated storage key.
+    1. Cordon the current node where the pod is running:
+
+        ```console
+        kubectl cordon <node-name>
+        ```
+
+    1. Force the pod to restart on a different node:
+
+        ```console
+        kubectl delete pod <pod-name>
+        ```
+
+    1. The new pod mounts the file share by using the updated credential.
+
+    **Option B: Scale replicas (Deployment/StatefulSet - recommended)**
+
+    1. Scale replicas down to 0:
+
+        ```console
+        kubectl scale deployment <deployment-name> --replicas=0
+        ```
+
+    1. Wait 3-5 minutes for the account key cache to expire.
+
+    1. Scale replicas back to the original count:
+
+        ```console
+        kubectl scale deployment <deployment-name> --replicas=<original-count>
+        ```
+
+    1. The new pods mount the file share by using the updated credentials.
 
 [!INCLUDE [Third-party disclaimer](../../../includes/third-party-disclaimer.md)]
 


### PR DESCRIPTION
# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.

# Why we need this PR

A customer reported that the current TSG did not resolve the issue when followed as documented. Based on findings from the discussion in GitHub [issue #802](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/802) and testing performed in my own cluster, this PR updates the TSG to reflect the correct troubleshooting and mitigation steps.