### PR TITLE
Add Secure Boot cert update troubleshooting for Azure Trusted Launch VMs (Windows + Linux)

### DIFF
--- a/support/azure/virtual-machines/linux/linux-vm-secure-boot-cert-updates-trusted-launch.md
+++ b/support/azure/virtual-machines/linux/linux-vm-secure-boot-cert-updates-trusted-launch.md
@@ -1,0 +1,228 @@
+---
+title: Troubleshoot Secure Boot certificate updates on Linux Trusted Launch VMs
+description: Diagnose and resolve Secure Boot certificate update issues on Azure Trusted Launch VMs running Linux, including shim bootloader and firmware certificate verification.
+ms.date: 06/05/2026
+author: scotro
+ms.author: scotro
+manager: dcscontentpm
+audience: ITPro
+ms.topic: troubleshooting
+ms.reviewer: arrenc
+ms.custom:
+- sap:virtual machines\vm management - configuration and setup
+- pcy:VM Conf and Setup
+appliesto:
+  - <a href=https://learn.microsoft.com/azure/virtual-machines/trusted-launch target=_blank>Azure Trusted Launch VMs</a>
+  - <a href=https://learn.microsoft.com/azure/confidential-computing/confidential-vm-overview target=_blank>Azure Confidential VMs</a>
+---
+
+# Troubleshoot Secure Boot certificate updates on Linux Trusted Launch VMs
+
+This article helps you diagnose and resolve Secure Boot certificate update issues on Azure Trusted Launch virtual machines (TVM) and Confidential VMs (CVM) running supported Linux distributions.
+
+## Applies to
+
+- Ubuntu Server 22.04 LTS, 20.04 LTS
+- Red Hat Enterprise Linux (RHEL) 9.4, 9.5, 9.6, 8.6, 8.8, 8.10
+- SUSE Enterprise Linux 15 SP3, SP4, SP5
+- Alma Linux 8.7, 8.8, 9.0
+- Rocky Linux 8.6, 8.10, 9.2, 9.4, 9.6
+- Oracle Linux 8.3–8.8, 9.0, 9.1
+- Debian 11, 12
+- Azure Linux 1.0, 2.0
+
+## How Linux Secure Boot differs from Windows
+
+Linux Trusted Launch VMs use the same Azure virtual firmware and Secure Boot certificate infrastructure as Windows VMs. The same Microsoft certificates (KEK, DB, DBX) are stored in the virtual firmware. However, the boot chain differs:
+
+| Component | Windows | Linux |
+|---|---|---|
+| Boot chain | Boot Manager → OS | **shim** → GRUB2 → kernel |
+| Cert that signs bootloader | Windows UEFI CA 2011/2023 | Microsoft UEFI CA 2011/2023 (signs shim) |
+| Guest-side monitoring | Registry + Event IDs | `mokutil`, `efi-readvar`, `dmesg` |
+| Update mechanism | Windows Update (automatic) | Platform firmware update + distro shim package |
+
+The **shim** bootloader is signed by Microsoft's UEFI CA. When the 2011 CA expires in June 2026, VMs need the 2023 CA in firmware to validate future shim updates.
+
+## Symptoms
+
+You experience one or more of the following on an Azure Gen2 Trusted Launch Linux VM:
+
+- VM fails to boot after a shim or GRUB update with a Secure Boot violation error.
+- `mokutil --sb-state` shows Secure Boot is enabled, but `mokutil --db` shows only 2011-era certificates.
+- `dmesg | grep -i secureboot` shows Secure Boot validation warnings.
+- VM created before March 2024 has not received firmware certificate updates.
+
+## Cause
+
+Microsoft Secure Boot certificates issued in 2011 begin expiring in June 2026. Azure Trusted Launch and Confidential VMs running Linux use the same firmware certificate infrastructure (DB, KEK, DBX) as Windows VMs. The firmware certificates are platform-managed and injected at VM creation time.
+
+Long-running VMs created before March 2024 may not have the 2023 certificates in virtual firmware. Without them, future shim and GRUB updates signed exclusively by the Microsoft UEFI CA 2023 won't validate against the firmware DB.
+
+> [!NOTE]
+> VMs created after March 2024 (including VMs deployed from older Marketplace images) receive 2023 certificates at creation. The at-risk population is VMs that have been continuously running since before March 2024.
+
+## Determine Secure Boot certificate status
+
+### Option 1: Run the diagnostic script via Run Command
+
+Use the **Detect-SecureBootCertStatus-Linux.sh** RunCommand script:
+
+1. In the Azure portal, navigate to your VM.
+2. Select **Operations** > **Run command** > **RunShellScript**.
+3. Download and paste the script from the [Azure Support Scripts repository](https://github.com/Azure/azure-support-scripts/tree/master/RunCommand/Linux/SecureBootCertCheck).
+4. Select **Run**.
+
+### Option 2: Check manually
+
+**Check Secure Boot state:**
+
+```bash
+# Is Secure Boot enabled?
+mokutil --sb-state
+
+# List certificates in the Secure Boot DB
+mokutil --db | grep -A2 "Certificate"
+
+# List certificates in KEK
+mokutil --kek | grep -A2 "Certificate"
+
+# Check for 2023 certificates specifically
+mokutil --db | grep -i "2023"
+```
+
+**Check shim version and signature:**
+
+```bash
+# Ubuntu/Debian
+dpkg -l | grep shim-signed
+apt list --installed 2>/dev/null | grep shim
+
+# RHEL/CentOS/Alma/Rocky/Oracle
+rpm -qa | grep shim
+rpm -qi shim-x64
+
+# SUSE
+rpm -qa | grep shim
+```
+
+**Check boot chain via dmesg:**
+
+```bash
+dmesg | grep -iE "secureboot|secure boot|uefi|shim|grub"
+```
+
+**Check EFI variables (requires root):**
+
+```bash
+# If efivarfs is mounted
+ls /sys/firmware/efi/efivars/ | grep -i SecureBoot
+
+# Read Secure Boot state directly
+cat /sys/firmware/efi/efivars/SecureBoot-*/data 2>/dev/null | xxd | head -1
+# Last byte: 01 = enabled, 00 = disabled
+```
+
+## Resolve certificate update issues
+
+### Firmware certificate updates (platform-managed)
+
+The Secure Boot certificates in virtual firmware (DB, KEK, DBX) are managed by the Azure platform, not by the Linux guest OS.
+
+- **VMs created after March 2024:** 2023 certificates are pre-provisioned in virtual firmware. No action needed for firmware certs.
+- **VMs created before March 2024:** Firmware certificates need updating. This update is coordinated between the guest OS and the Azure host platform.
+
+> [!NOTE]
+> The same Event 1795 host firmware issue that affected Windows VMs also affects Linux VMs. The host-side fix shipped in the Azure 2605_2 host OS servicing package (rolled out by end of May 2026). If firmware cert updates fail, restart or redeploy the VM.
+
+### Shim bootloader updates (distro-managed)
+
+Each Linux distribution ships its own shim bootloader, signed by Microsoft's UEFI CA. Distro maintainers must provide updated shims signed by the new Microsoft UEFI CA 2023.
+
+**Update shim to the latest version:**
+
+```bash
+# Ubuntu/Debian
+sudo apt update && sudo apt install --only-upgrade shim-signed grub-efi-amd64-signed
+
+# RHEL/CentOS/Alma/Rocky/Oracle
+sudo dnf update shim-x64 grub2-efi-x64
+
+# SUSE
+sudo zypper update shim grub2-x86_64-efi
+```
+
+After updating, restart the VM:
+
+```bash
+sudo reboot
+```
+
+### Verify after update
+
+```bash
+# Confirm Secure Boot is still enabled
+mokutil --sb-state
+
+# Check that 2023 certificates are in DB
+mokutil --db | grep -i "2023"
+
+# Verify boot completed without errors
+dmesg | grep -iE "secureboot|secure boot" | tail -5
+journalctl -b | grep -i "secure boot"
+```
+
+## Pre-March 2024 VMs vs. newer VMs
+
+| VM Creation Date | Firmware Certs | Shim Status | Action |
+|---|---|---|---|
+| **After March 2024** | 2023 certs pre-provisioned | Depends on image freshness | Update shim package from distro repos |
+| **Before March 2024** | 2011 certs only | May have older shim | Restart/redeploy VM for firmware update + update shim |
+
+## Impact of not updating
+
+Linux VMs that don't receive the 2023 certificates will:
+
+- **Continue to boot normally** with the current shim/GRUB/kernel chain.
+- **Not be able to validate** future shim or GRUB updates signed exclusively with the 2023 CA.
+- Have a **degraded security posture** — new boot-level security fixes may require the 2023 CA for signature validation.
+- **Not** experience an immediate boot failure — the existing trust chain continues to work until old certificates are actively revoked via DBX.
+
+> [!IMPORTANT]
+> Azure cannot force Secure Boot certificate updates remotely via the hypervisor. The firmware certificate update requires platform coordination triggered by the guest OS. For the shim bootloader, customers must update via their distribution's package manager.
+
+## Distro-specific considerations
+
+### Ubuntu
+
+- Canonical ships `shim-signed` package with shims signed by Microsoft.
+- Check: `dpkg -l shim-signed | grep -E "^ii"`
+- Ubuntu 22.04 LTS images from Azure Marketplace should have recent shims.
+
+### RHEL
+
+- Red Hat ships `shim-x64` package.
+- Check: `rpm -q shim-x64`
+- RHEL 8.x and 9.x images in Marketplace are maintained by Red Hat.
+
+### SUSE
+
+- SUSE ships `shim` package.
+- Check: `rpm -q shim`
+- SLES 15 SP3+ supports Trusted Launch.
+
+### Azure Linux (Mariner/Azure Linux)
+
+- Microsoft-maintained shim — updates ship via Azure Linux package repos.
+- Check: `rpm -q shim-unsigned-x64` or `rpm -q shim`
+
+## More information
+
+- [Secure Boot update from 2011 to 2023 certificates: TVM and CVM (KB 5085395)](https://support.microsoft.com/topic/845ec199-03fa-4629-bdc3-822ae0bbe6ca)
+- [Trusted Launch for Azure virtual machines](/azure/virtual-machines/trusted-launch)
+- [Known issues and resolutions for Secure Boot certificates updates (KB 5085790)](https://support.microsoft.com/topic/5813673d-2577-4718-ad28-2554a9178e40)
+- [Troubleshoot Secure Boot certificate updates on Windows Trusted Launch VMs](../windows/troubleshoot-secure-boot-cert-updates-trusted-launch.md)
+
+[!INCLUDE [Third-party information disclaimer](../../../includes/third-party-disclaimer.md)]
+
+[!INCLUDE [Azure Help Support](../../../includes/azure-help-support.md)]

--- a/support/azure/virtual-machines/linux/linux-vm-secure-boot-cert-updates-trusted-launch.md
+++ b/support/azure/virtual-machines/linux/linux-vm-secure-boot-cert-updates-trusted-launch.md
@@ -4,6 +4,7 @@ description: Diagnose and resolve Secure Boot certificate update issues on Azure
 ms.date: 06/05/2026
 author: scotro
 ms.author: scotro
+ms.service: azure-virtual-machines
 manager: dcscontentpm
 audience: ITPro
 ms.topic: troubleshooting

--- a/support/azure/virtual-machines/linux/toc.yml
+++ b/support/azure/virtual-machines/linux/toc.yml
@@ -144,6 +144,15 @@ items:
     - name: Troubleshoot SLES migration issues
       href: linux-upgrade-sles.md
 
+- name: Secure Boot certificate updates (Trusted Launch)
+  items:
+  - name: Troubleshoot Secure Boot certificate updates on Linux
+    href: linux-vm-secure-boot-cert-updates-trusted-launch.md
+  - name: Trusted Launch for Azure virtual machines
+    href: /azure/virtual-machines/trusted-launch?context=/troubleshoot/azure/virtual-machines/linux/context/context
+  - name: Secure Boot update for TVM and CVM (KB 5085395)
+    href: https://support.microsoft.com/topic/845ec199-03fa-4629-bdc3-822ae0bbe6ca
+
 - name: My VM is not booting
   items:
   - name: Linux - Specific scenarios

--- a/support/azure/virtual-machines/windows/toc.yml
+++ b/support/azure/virtual-machines/windows/toc.yml
@@ -341,6 +341,15 @@ items:
   - name: Troubleshooting Tool
     href: windows-vm-imds-tool.md
 
+- name: Secure Boot certificate updates (Trusted Launch)
+  items:
+  - name: Troubleshoot Secure Boot certificate updates
+    href: troubleshoot-secure-boot-cert-updates-trusted-launch.md
+  - name: Secure Boot certificate update overview (KB 5062710)
+    href: https://support.microsoft.com/topic/7ff40d33-95dc-4c3c-8725-a9b95457578e
+  - name: Known issues for Secure Boot certificate updates (KB 5085790)
+    href: https://support.microsoft.com/topic/5813673d-2577-4718-ad28-2554a9178e40
+
 - name: My VM is not booting
   items:
   - name: Boot diagnostics

--- a/support/azure/virtual-machines/windows/troubleshoot-secure-boot-cert-updates-trusted-launch.md
+++ b/support/azure/virtual-machines/windows/troubleshoot-secure-boot-cert-updates-trusted-launch.md
@@ -4,6 +4,7 @@ description: Diagnose and resolve Secure Boot certificate update issues on Azure
 ms.date: 06/05/2026
 author: scotro
 ms.author: scotro
+ms.service: azure-virtual-machines
 manager: dcscontentpm
 audience: ITPro
 ms.topic: troubleshooting
@@ -107,7 +108,7 @@ The host-side fix was included in the Azure 2605_2 host OS servicing package, wh
 
 If Event ID 1795 persists after restarting:
 1. Redeploy the VM (`az vm redeploy`) to force placement on a different host node.
-2. If the issue continues, [create an Azure support request](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request) referencing Event ID 1795.
+2. If the issue continues, [create an Azure support request](/azure/azure-portal/supportability/how-to-create-azure-support-request) referencing Event ID 1795.
 
 > [!NOTE]
 > There is no guest-side workaround for Event ID 1795. The host node must have the firmware update. The guest OS cannot resolve this independently.

--- a/support/azure/virtual-machines/windows/troubleshoot-secure-boot-cert-updates-trusted-launch.md
+++ b/support/azure/virtual-machines/windows/troubleshoot-secure-boot-cert-updates-trusted-launch.md
@@ -1,0 +1,198 @@
+---
+title: Troubleshoot Secure Boot certificate updates on Azure Trusted Launch VMs
+description: Diagnose and resolve Secure Boot certificate update issues on Azure Trusted Launch and Confidential VMs running Windows, including Event ID 1795 firmware errors.
+ms.date: 06/05/2026
+author: scotro
+ms.author: scotro
+manager: dcscontentpm
+audience: ITPro
+ms.topic: troubleshooting
+ms.reviewer: arrenc
+ms.custom:
+- sap:virtual machines\vm management - configuration and setup
+- pcy:VM Conf and Setup
+appliesto:
+  - <a href=https://learn.microsoft.com/azure/virtual-machines/trusted-launch target=_blank>Azure Trusted Launch VMs</a>
+  - <a href=https://learn.microsoft.com/azure/confidential-computing/confidential-vm-overview target=_blank>Azure Confidential VMs</a>
+---
+
+# Troubleshoot Secure Boot certificate updates on Azure Trusted Launch VMs
+
+This article helps you diagnose and resolve issues with Secure Boot certificate updates on Azure Trusted Launch virtual machines (TVM) and Confidential VMs (CVM) running Windows.
+
+## Symptoms
+
+You experience one or more of the following issues on an Azure Gen2 Trusted Launch or Confidential VM:
+
+- **Event ID 1795** in the System event log: "The system firmware returned an error while attempting to update a Secure Boot variable."
+- **Event ID 1801** indicating the certificate update is incomplete.
+- The `UEFICA2023Status` registry value is not set to **Updated**.
+- The `UEFICA2023Error` registry key exists under `HKLM\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing`.
+
+## Cause
+
+Microsoft Secure Boot certificates issued in 2011 begin expiring in June 2026. Azure Trusted Launch and Confidential VMs must update to the 2023 certificates to maintain boot-level security protections. Several factors can prevent these updates from completing:
+
+| Root Cause | Symptom | Details |
+|---|---|---|
+| **Host firmware not updated** | Event ID 1795 | The Azure host node had not received the firmware update needed to support guest-initiated KEK updates. This affected long-running VMs where UEFI NVRAM writes require host platform coordination. **Resolved:** The host-side fix shipped in the 2605_2 host OS servicing package (rolled out by end of May 2026). |
+| **VM created before March 2024** | Certificate update doesn't complete | Long-running VMs created before March 2024 don't have the 2023 certificates pre-provisioned in virtual firmware. These VMs require both certificate updates AND a Boot Manager update. |
+| **Scheduled task disabled** | `UEFICA2023Status` stays empty | The `Secure-Boot-Update` scheduled task is disabled, preventing automatic certificate deployment. |
+| **Missing servicing stack update** | `Servicing` registry key doesn't exist | The Secure Boot servicing stack update hasn't been installed. The VM needs the March 2026 cumulative update or later. |
+| **Hotpatch-only VMs** | Update not applied | VMs using hotpatching need the April 2026 release that includes the fix outside of hotpatching. |
+
+## Determine certificate update status
+
+### Option 1: Run the diagnostic script via Run Command
+
+Use the **Detect-SecureBootCertUpdateStatus_Summary.ps1** RunCommand script to collect a comprehensive status report.
+
+1. In the Azure portal, navigate to your VM.
+2. Select **Operations** > **Run command** > **RunPowerShellScript**.
+3. Download and paste the script from the [Azure Support Scripts repository](https://github.com/Azure/azure-support-scripts/tree/master/RunCommand/Windows/SecureBootCertCheck).
+4. Select **Run**.
+
+The script checks:
+- Secure Boot enabled state
+- `AvailableUpdates` bitmask (decoded into human-readable certificate flags)
+- `UEFICA2023Status` and error values
+- Event log analysis for all relevant Event IDs (1795–1808)
+- Scheduled task state and last run time
+- OEM firmware version
+
+### Option 2: Check manually
+
+**Registry check:**
+
+```powershell
+# Certificate update status
+Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing" | Select-Object UEFICA2023Status, UEFICA2023Error, UEFICA2023ErrorEvent
+
+# Available updates bitmask
+Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot" | Select-Object AvailableUpdates
+```
+
+| UEFICA2023Status value | Meaning |
+|---|---|
+| **Updated** | Certificates successfully applied |
+| **InProgress** | Update started but not complete (restart may be needed) |
+| **NotStarted** | On post-March 2024 VMs, this is **expected** — firmware already has 2023 certs pre-provisioned, so guest-side cert deployment was never needed. On pre-March 2024 VMs, this means the update hasn't been initiated yet. |
+| *Not present* | Servicing key doesn't exist — update hasn't been initiated at all |
+
+**Event log check:**
+
+```powershell
+Get-WinEvent -FilterHashtable @{LogName='System'; ProviderName='TPM-WMI'; Id=1795,1800,1801,1803,1808} -MaxEvents 10 | Format-Table TimeCreated, Id, Message -Wrap
+```
+
+| Event ID | Meaning | Action |
+|---|---|---|
+| 1808 | Success — certificates applied | None |
+| 1801 | Update initiated, pending restart | Restart the VM |
+| 1800 | Restart required to complete | Restart the VM |
+| 1803 | Matching KEK not found | Should not occur on standard Azure VMs — contact support |
+| 1795 | Firmware error | See [Resolve Event ID 1795](#resolve-event-id-1795) |
+
+## Resolve Event ID 1795
+
+Event ID 1795 on Azure Trusted Launch VMs was caused by unpatched host firmware that didn't support guest-initiated UEFI NVRAM writes for KEK updates.
+
+**Resolution:**
+
+The host-side fix was included in the Azure 2605_2 host OS servicing package, which completed fleet-wide rollout by end of May 2026.
+
+1. **Restart the VM** to allow the VM to land on an updated host node.
+2. After restart, wait approximately 48 hours and one or more restarts for the certificate update to complete automatically.
+3. Run the diagnostic script or check the registry to verify `UEFICA2023Status = Updated`.
+
+If Event ID 1795 persists after restarting:
+1. Redeploy the VM (`az vm redeploy`) to force placement on a different host node.
+2. If the issue continues, [create an Azure support request](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request) referencing Event ID 1795.
+
+> [!NOTE]
+> There is no guest-side workaround for Event ID 1795. The host node must have the firmware update. The guest OS cannot resolve this independently.
+
+## Resolve stalled certificate updates
+
+### Certificate update not initiated
+
+If the `Servicing` registry key doesn't exist:
+
+1. Install the latest Windows cumulative update (March 2026 or later).
+2. Restart the VM.
+3. Wait for automatic deployment via Windows Update.
+4. If automatic deployment doesn't occur, use an IT-initiated method:
+
+```powershell
+# Enable IT-initiated deployment via registry
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot" -Name "AvailableUpdates" -PropertyType DWord -Value 0x5944 -Force
+```
+
+### Scheduled task disabled
+
+```powershell
+# Check task status
+Get-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update" | Select-Object State
+
+# Re-enable if disabled
+Enable-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update"
+```
+
+### Update stuck in progress
+
+If `UEFICA2023Status` shows **InProgress** for more than 48 hours:
+
+1. Restart the VM.
+2. Check status after 15 minutes.
+3. If still in progress, check for `UEFICA2023Error` and review System event logs.
+
+## Pre-March 2024 VMs vs. newer VMs
+
+| VM Creation Date | Firmware Certs | Action Required |
+|---|---|---|
+| **After March 2024** | 2023 certificates pre-provisioned | Only Windows Boot Manager update needed |
+| **Before March 2024** | 2011 certificates only | Both firmware certificate update AND Boot Manager update needed |
+
+> [!IMPORTANT]
+> The "before March 2024" distinction refers to VMs that have been **continuously running since before March 2024** — not VMs deployed from older images. Azure injects current firmware certificates at VM creation time regardless of image age. You cannot reproduce the missing-certs scenario by deploying an old Marketplace image today.
+
+For VMs created before March 2024, the certificate updates must be applied from within the guest OS through Windows servicing. Azure cannot push these updates from the hypervisor — the UEFI authenticated variable update protocol requires guest OS initiation.
+
+## Golden image considerations
+
+Azure Compute Gallery and managed images capture OS state (including Boot Manager) but **do not capture Secure Boot firmware variables** (DB, KEK, DBX).
+
+- Apply the Secure Boot 2023 update to the golden image before capturing.
+- This advances the Windows Boot Manager in the image but does NOT persist certificates to VMs deployed from the image.
+- Newly provisioned VMs (post-March 2024) get 2023 certs automatically in firmware.
+- Redeploying onto pre-March 2024 VMs requires applying cert updates in the guest OS first, before advancing the Boot Manager.
+
+Verify before generalizing:
+
+```powershell
+Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\Servicing" | Select-Object UEFICA2023Status
+# Expected: UEFICA2023Status = Updated
+```
+
+## Impact of not updating
+
+VMs that don't receive the 2023 certificates will:
+- **Continue to boot normally** and receive standard Windows updates.
+- **Not receive** new Boot Manager security updates, Secure Boot database/revocation updates, or mitigations for future boot-level vulnerabilities.
+- Operate with a **degraded security posture** for the early boot process over time.
+
+> [!IMPORTANT]
+> Azure cannot force Secure Boot certificate updates remotely via the hypervisor. The guest OS must initiate the update. Customers with long-running VMs must apply updates from within the guest OS or accept the degraded boot-level security posture after June 2026.
+
+## More information
+
+- [Secure Boot update from 2011 to 2023 certificates: TVM and CVM (KB 5085395)](https://support.microsoft.com/topic/845ec199-03fa-4629-bdc3-822ae0bbe6ca)
+- [Known issues and resolutions for Secure Boot certificates updates (KB 5085790)](https://support.microsoft.com/topic/5813673d-2577-4718-ad28-2554a9178e40)
+- [Windows Secure Boot certificate expiration and CA updates (KB 5062710)](https://support.microsoft.com/topic/7ff40d33-95dc-4c3c-8725-a9b95457578e)
+- [Secure Boot playbook for Windows Server](https://aka.ms/SecureBootForServer)
+- [SecureBootCertCheck RunCommand script](https://github.com/Azure/azure-support-scripts/tree/master/RunCommand/Windows/SecureBootCertCheck)
+- [Trusted Launch for Azure virtual machines](/azure/virtual-machines/trusted-launch)
+
+[!INCLUDE [Third-party information disclaimer](../../../includes/third-party-disclaimer.md)]
+
+[!INCLUDE [Azure Help Support](../../../includes/azure-help-support.md)]


### PR DESCRIPTION
## Summary

Two new troubleshooting articles for Azure Trusted Launch VMs covering Secure Boot certificate updates (June 2026 cert expiry, CVE-2023-24932).

### New articles
- **Windows**: troubleshoot-secure-boot-cert-updates-trusted-launch.md
- **Linux**: linux-vm-secure-boot-cert-updates-trusted-launch.md

### TOC updates
- Added 'Secure Boot certificate updates (Trusted Launch)' section to both Windows and Linux TOCs

### Validation
- Tested on 5 Azure Trusted Launch VMs: WS2022 (latest + oldest image), Ubuntu 22.04 (latest + Dec 2023 image), RHEL 9.4
- Event 1795 detection verified via mock test
- Both dpkg (Ubuntu) and rpm (RHEL) RunCommand code paths validated
- Key finding: Azure injects current firmware certs at VM creation regardless of image age

### Related
- ICM 765582227 (Secure Boot cert baseline)
- ICM 777380766 (Event 1795 KEK failures)
- KB 5085395 (TVM/CVM guidance)
- KB 5085790 (Known issues)