### PR TITLE
Update troubleshoot-application-gateway-deployment-scaling-deletion-f…

### DIFF
--- a/support/azure/application-gateway/troubleshoot-application-gateway-deployment-scaling-deletion-failures.md
+++ b/support/azure/application-gateway/troubleshoot-application-gateway-deployment-scaling-deletion-failures.md
@@ -1305,7 +1305,7 @@ az group export \
 6. To remove the orphaned references, edit `appgw-template.json`. 
 7. Before you redeploy, apply the following mandatory edits (the raw `az group export` output isn't redeployable verbatim):
 
-- Remove the Application Gateway's top-level `dependsOn` array. `az group export` omits a circular dependency for Application Gateway resources. Therefore, the redeployment fails and returns `InvalidTemplate: Circular dependency detected`. ARM infers the correct ordering from the `resourceId(...)` property references. Therefore, you can delete the top-level `dependsOn` on the `Microsoft.Network/applicationGateways` resource to resolve it.
+- Remove the Application Gateway's top-level `dependsOn` array. `az group export` issues a circular dependency for Application Gateway resources. Therefore, the redeployment fails and returns `InvalidTemplate: Circular dependency detected`. ARM infers the correct ordering from the `resourceId(...)` property references. Therefore, you can delete the top-level `dependsOn` on the `Microsoft.Network/applicationGateways` resource to resolve it.
 - Supply values for the exported resource-name parameters. `az group export` creates name parameters (for example, the gateway, virtual network, and public IP name parameters) without any `defaultValue`. Therefore, the redeployment stalls in a `stdin` state as it waits for input unless you pass them. Provide a value for each exported name parameter by using `--parameters <paramName>=<value>` on the redeploy command (see the following commands).
 
 8. Redeploy the edited template. Supply a value for each exported name parameter.


### PR DESCRIPTION
…ailures.md

In "Resolution H / step 7," changed "omits" to "issues." This was incorrectly changed from the original "emits." However, "emits" could be translated as "ejects," "expels," or "leaks.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
