### PR TITLE
Fix broken best-practices anchor links in AKS API server/etcd troubleshoot

### DIFF
--- a/support/azure/azure-kubernetes/create-upgrade-delete/troubleshoot-apiserver-etcd.md
+++ b/support/azure/azure-kubernetes/create-upgrade-delete/troubleshoot-apiserver-etcd.md
@@ -187,7 +187,7 @@ kubectl get events -n kube-system aks-managed-apiserver-throttling-enabled
 
 #### Step 1: Identify unoptimized clients
 
-- See [Cause 5](#cause-5-an-offending-client-makes-excessive-list-or-put-calls) to identify problematic clients and refine their LIST call patterns - especially those clients generating high-frequency or high-latency requests as they are the primary contributors to API server degradation. Refer to [best practices](/azure/aks/best-practices-performance-scale-large#kubernetes-clients) for further guidance on client optimization.
+- See [Cause 5](#cause-5-an-offending-client-makes-excessive-list-or-put-calls) to identify problematic clients and refine their LIST call patterns - especially those clients generating high-frequency or high-latency requests as they are the primary contributors to API server degradation. Refer to [best practices](/azure/aks/best-practices-performance-scale-large#kubernetes-client-best-practices) for further guidance on client optimization.
 
 #### Step 2: Mitigation
 
@@ -200,7 +200,7 @@ kubectl delete flowschema aks-managed-apiserver-guard
 kubectl delete prioritylevelconfiguration aks-managed-apiserver-guard
 ```
 > [!WARNING]
-> Avoid scaling the cluster back to the originally intended scale point  until client call patterns have been optimized, refer to **[best practices](/azure/aks/best-practices-performance-scale-large#kubernetes-clients)**. Premature scaling may cause the API server to crash again.
+> Avoid scaling the cluster back to the originally intended scale point  until client call patterns have been optimized, refer to **[best practices](/azure/aks/best-practices-performance-scale-large#kubernetes-client-best-practices)**. Premature scaling may cause the API server to crash again.
 
 - You can also [modify the aks-managed-apiserver-guard FlowSchema and PriorityLevelConfiguration](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/#good-practice-apf-settings) by applying the label **aks-managed-skip-update-operation: true**. This label preserves the modified configurations and prevents AKS from reconciling them back to default values. This is relevant if you are applying a custom FlowSchema and PriorityLevelConfiguration tailored to your cluster's requirements as specified in [solution 5b](#solution-5b-throttle-a-client-thats-overwhelming-the-control-plane) and do not want AKS to automatically manage client throttling.
 
@@ -363,7 +363,7 @@ The results from this query can help you identify the kinds of API calls that fa
 
 ### Solution 5a: Tune your API call pattern
 
-To reduce the pressure on the control plane, consider tuning your client's API server call pattern. Refer to [best practices](/azure/aks/best-practices-performance-scale-large#kubernetes-clients#kubernetes-clients).
+To reduce the pressure on the control plane, consider tuning your client's API server call pattern. Refer to [best practices](/azure/aks/best-practices-performance-scale-large#kubernetes-client-best-practices).
 
 ### Solution 5b: Throttle a client that's overwhelming the control plane
 


### PR DESCRIPTION
The #kubernetes-clients anchor no longer exists on the AKS best-practices-performance-scale-large page. Update three links to the current #kubernetes-client-best-practices anchor and remove a duplicated anchor fragment in Solution 5a.
