### PR TITLE
AKS: fix incorrect etcd wording in API server troubleshooting article

### DIFF
--- a/support/azure/azure-kubernetes/create-upgrade-delete/troubleshoot-apiserver-etcd.md
+++ b/support/azure/azure-kubernetes/create-upgrade-delete/troubleshoot-apiserver-etcd.md
@@ -15,7 +15,7 @@ ms.custom: sap:Create, Upgrade, Scale and Delete operations (cluster or nodepool
 
 This article helps you troubleshoot API server and etcd problems in large Azure Kubernetes Service (AKS) deployments.
 
-Microsoft tests the reliability and performance of the API server at a scale of 5,000 nodes and 200,000 pods. The cluster that contains the API server can automatically scale out and deliver [Kubernetes Service Level Objectives (SLOs)](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md). If you experience high latencies or timeouts, the cause is likely a resource leakage on the distributed `etc` directory (etcd), or an offending client that has excessive API calls.
+Microsoft tests the reliability and performance of the API server at a scale of 5,000 nodes and 200,000 pods. The cluster that contains the API server can automatically scale out and deliver [Kubernetes Service Level Objectives (SLOs)](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md). If you experience high latencies or timeouts, the cause is likely a resource leakage on the distributed `etcd`, or an offending client that has excessive API calls.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
This PR fixes an inaccurate wording in the AKS API server troubleshooting article.
The current text refers to a "distributed `etc` directory (etcd)", which can be confusing because `etc` may be interpreted as the Linux `/etc` directory. The intended component is `etcd`, the Kubernetes control plane data store.

## Updates
Changed:
> resource leakage on the distributed `etc` directory (etcd)
To:
> resource leak in `etcd`