### PR TITLE
Fix stray space in VMSS instance name example

### DIFF
--- a/support/azure/azure-kubernetes/create-upgrade-delete/error-code-k8sapiserverdnslookupfailvmextensionerror.md
+++ b/support/azure/azure-kubernetes/create-upgrade-delete/error-code-k8sapiserverdnslookupfailvmextensionerror.md
@@ -34,7 +34,7 @@ When you try to start or create an AKS cluster, you receive the following error 
 >
 > "ExitCode": "52",
 >
-> "Output": "Fri Oct 15 10:06:00 UTC 2021,aks- nodepool1-36696444-vmss000000\\nConnection to mcr.microsoft.com 443 port [tcp/https]
+> "Output": "Fri Oct 15 10:06:00 UTC 2021,aks-nodepool1-36696444-vmss000000\\nConnection to mcr.microsoft.com 443 port [tcp/https]
 
 ## Cause
 


### PR DESCRIPTION
Fixes a typo on line 37 of error-code-k8sapiserverdnslookupfailvmextensionerror.md. "aks- nodepool1-36696444-vmss000000" contained a stray space after "aks-", which does not match a real VMSS instance name format (e.g. "aks-nodepool1-36696444-vmss000000").