### PR TITLE
Fixing and improving issues in the Logback sample

### DIFF
--- a/support/azure/azure-monitor/app-insights/telemetry/auto-instrumentation-troubleshoot.md
+++ b/support/azure/azure-monitor/app-insights/telemetry/auto-instrumentation-troubleshoot.md
@@ -157,15 +157,15 @@ Add the following filter to your logback.xml:
 Example:
 
 ```xml
-<configuration debug="true">
+<configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>OFF</level>
+    </filter>  
     <!-- encoders are  by default assigned the type
          ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
-      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-        <level>OFF</level>
-      </filter>  
     </encoder>
   </appender>
   <root level="debug">


### PR DESCRIPTION
Fixing:
In Logback sample, a `<filter>` is a child of the `<appender>`, not of the `<encoder>`. `PatternLayoutEncoder` has no `filter` sub-element, so a filter placed there is silently ignored. As a result, the console (stdout) output is NOT suppressed, the Functions host still captures stdout, and the duplicate logs the workaround is meant to prevent. ->Fixed the sample so that `<filter>` becomes a child of `<appender>`.

Improving:
The sample uses <configuration debug="true">, which prints Logback's own status output to the console and is counterproductive for an example whose purpose is to suppress console output. ->Removing debug="true". 

The Log4j sample in the same section is correct and needs no change.

# Pull request guidance

Thank you for submitting your contribution to our support content! Our team works closely with subject matter experts in CSS and PMs in the product group to review all content requests to ensure technical accuracy and the best customer experience. This process can sometimes take one or more days, so we greatly appreciate your patience.

We also need your help in order to process your request as soon as possible:

- We won't act on your pull request (PR) until you type "**#sign-off**" in a new comment in your pull request (PR) to indicate that your changes are complete.

- After you sign off in your PR, the article will be tech reviewed by the PM or SME if it has more than minor changes. Once the article is approved, it will undergo a final editing pass before being merged.
