### PR TITLE
Expand remediation options for AKS allocated outbound port validation

### DIFF
--- a/support/azure/azure-kubernetes/create-upgrade-delete/error-code-invalidloadbalancerprofileallocatedoutboundports.md
+++ b/support/azure/azure-kubernetes/create-upgrade-delete/error-code-invalidloadbalancerprofileallocatedoutboundports.md
@@ -51,9 +51,16 @@ To resolve the "InvalidLoadBalancerProfileAllocatedOutboundPorts" error, follow 
     > [!NOTE]
     > When performing this check, make sure you consider node surges that happen during cluster upgrades and other operations. AKS defaults to one buffer node for upgrade operations, but this number can be modified using the [maxSurge](/azure/aks/upgrade-aks-cluster#customize-node-surge-upgrade) parameter.
 
-2. Change the cluster's node count, the number of outbound frontend IP addresses, or the number of SNAT ports per node.
+2. Make one or more of the following changes:
 
-    For more information about how to configure the allocated outbound ports and examples and calculations of the number of ports you might need, see [Configure the allocated outbound ports](/azure/aks/load-balancer-standard#configure-the-allocated-outbound-ports).
+    - Increase the number of outbound frontend IP addresses.
+    - Reduce the value of `allocatedOutboundPorts`.
+    - Reduce the node count or the cluster autoscaler `maxCount`.
+    - Reduce `maxSurge` if doing so is appropriate for your workload availability and upgrade requirements.
+
+    For the error example in this article, adding a second outbound IP increases the available SNAT ports from 64,000 to 128,000, which supports the required 72,000 ports.
+
+    For more information about configuring allocated outbound ports and calculating the number of ports you might need, see [Configure the allocated outbound ports](/azure/aks/load-balancer-standard#configure-the-allocated-outbound-ports).
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Expands the remediation guidance for the `InvalidLoadBalancerProfileAllocatedOutboundPorts` error.

Article updated:

`support/azure/azure-kubernetes/create-upgrade-delete/error-code-invalidloadbalancerprofileallocatedoutboundports.md`

## Changes

- Convert the existing remediation sentence into a list of actionable options.
- Clarify that customers can:
  - Increase the number of outbound frontend IP addresses.
  - Reduce `allocatedOutboundPorts`.
  - Reduce the node count or autoscaler `maxCount`.
  - Reduce `maxSurge` when appropriate for workload availability requirements.
- Add an example showing that a second outbound IP provides 128,000 SNAT ports and resolves the article's 72,000-port requirement.

## Reason for change

The current article mentions only the cluster node count, outbound IP count, and ports per node. It doesn't identify autoscaler `maxCount` or `maxSurge` as values that can affect the validation node count.

The expanded guidance gives customers specific configuration options for resolving the error.

## Validation

The remediation options follow the AKS RP validation inputs used to calculate required and available SNAT ports.

## Scope

This PR changes only the remediation guidance. It doesn't modify the Cause section, feasibility formula, or upgrade-surge calculation.