### PR TITLE
Update AKS upgrade surge references for allocated outbound ports

### DIFF
--- a/support/azure/azure-kubernetes/create-upgrade-delete/error-code-invalidloadbalancerprofileallocatedoutboundports.md
+++ b/support/azure/azure-kubernetes/create-upgrade-delete/error-code-invalidloadbalancerprofileallocatedoutboundports.md
@@ -55,8 +55,11 @@ To resolve the "InvalidLoadBalancerProfileAllocatedOutboundPorts" error, follow 
 
     For more information about how to configure the allocated outbound ports and examples and calculations of the number of ports you might need, see [Configure the allocated outbound ports](/azure/aks/load-balancer-standard#configure-the-allocated-outbound-ports).
 
-## Reference
+## References
 
-[Use Source Network Address Translation (SNAT) for outbound connections](/azure/load-balancer/load-balancer-outbound-connections)
+- [Configure rolling upgrades for AKS node pools](/azure/aks/upgrade-aks-node-pools-rolling#customize-node-surge)
+- [AgentPoolUpgradeSettings](/rest/api/aks/agent-pools/create-or-update#agentpoolupgradesettings)
+- [Configure the allocated outbound ports](/azure/aks/load-balancer-standard#configure-the-allocated-outbound-ports)
+- [Use Source Network Address Translation (SNAT) for outbound connections](/azure/load-balancer/load-balancer-outbound-connections)
 
  


### PR DESCRIPTION
## Summary

Updates and expands the references in the `InvalidLoadBalancerProfileAllocatedOutboundPorts` troubleshooting article.

Article updated:

`support/azure/azure-kubernetes/create-upgrade-delete/error-code-invalidloadbalancerprofileallocatedoutboundports.md`

## Changes

- Add the current AKS rolling-upgrade documentation:
  - [Configure rolling upgrades for AKS node pools](https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-node-pools-rolling#customize-node-surge)
- Add the AgentPool API reference that documents the default `maxSurge` value:
  - [AgentPoolUpgradeSettings](https://learn.microsoft.com/en-us/rest/api/aks/agent-pools/create-or-update#agentpoolupgradesettings)
- Retain the existing references for:
  - Configuring allocated outbound ports.
  - Azure Load Balancer SNAT outbound connections.

## Reason for change

The article currently links to an outdated `upgrade-aks-cluster` anchor. The replacement page contains the current node pool rolling-upgrade and `maxSurge` guidance.

The AgentPool API reference also provides the authoritative definition and current default value for `maxSurge`.

## Scope

This PR updates documentation links and references only. It doesn't change the troubleshooting calculations or remediation behavior.