### PR TITLE
Clarify BCD volume validation in WinRE

### DIFF
--- a/support/windows-client/performance/windows-boot-issues-troubleshooting.md
+++ b/support/windows-client/performance/windows-boot-issues-troubleshooting.md
@@ -126,6 +126,32 @@ BOOTREC /FIXBOOT
 
 If you receive BCD-related errors, follow these steps:
 
+> [!IMPORTANT]
+> Drive letters in Windows Recovery Environment (WinRE) can differ from the drive letters in the running Windows installation. On systems with multiple disks or EFI System Partitions, don't assume that Windows is on drive C or that the first EFI System Partition contains the active BCD store.
+
+1. Identify the Windows volume and, on UEFI-based computers, the EFI System Partition. For example, run the following commands and note the volume letters:
+
+   ```console
+   diskpart
+   list volume
+   exit
+   ```
+
+1. Verify the offline Windows volume by checking for the operating system loader and kernel. Replace `<WindowsVolume>` with the volume letter that you identified:
+
+   ```console
+   dir <WindowsVolume>:\Windows\System32\winload.efi
+   dir <WindowsVolume>:\Windows\System32\ntoskrnl.exe
+   ```
+
+1. Enumerate the BCD store and verify that both `device` and `osdevice` in the applicable Windows Boot Loader entry reference the offline Windows volume. On a UEFI-based computer, use the following command if you need to inspect a specific EFI System Partition:
+
+   ```console
+   bcdedit /store <SystemPartition>:\EFI\Microsoft\Boot\BCD /enum all
+   ```
+
+   If multiple EFI System Partitions or Windows Boot Manager firmware entries exist, inspect each relevant BCD store before making changes. Export the applicable BCD store before you modify it.
+
 1. Scan for all the systems that are installed. To do this step, run the following command:
 
    ```console


### PR DESCRIPTION
## Summary

- warn that WinRE drive letters can differ from the running Windows installation
- add steps to identify the offline Windows and EFI System Partition volumes
- verify both `device` and `osdevice` in the applicable Windows Boot Loader entry
- add guidance for systems with multiple disks, EFI System Partitions, or firmware boot entries

## Motivation

This guidance is based on a recovered Windows 11 Pro Insider Preview 26H2 system that failed with `winload.efi` and `0xc000000f`. The active BCD loader entry referenced `D:`, while the actual Windows installation, `winload.efi`, and `ntoskrnl.exe` were on `C:`. Correcting the BCD volume references removed the error.

The case also involved two GPT disks, two EFI System Partitions, two firmware Windows Boot Manager entries, and an incomplete installation that later rolled back successfully.

The observed BCD mismatch is not presented as proof that Windows Setup caused it. The state may have resulted from an interaction among the failed installation or rollback, multiple EFI partitions, previous recovery operations, manually rebuilt EFI files, or firmware boot-path selection.

## Validation

- `git diff --check` passes
- commands use placeholders instead of assuming that Windows is on `C:`
- the change modifies only the BCD troubleshooting section
